### PR TITLE
Add verifyhost = false

### DIFF
--- a/lib/services/Providers/Services_Providers_Http.php
+++ b/lib/services/Providers/Services_Providers_Http.php
@@ -200,6 +200,7 @@ class Services_Providers_Http {
         // eg, if a site returns an 400 we might want to know why.
         curl_setopt ($ch, CURLOPT_HEADER, 1);
         curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt ($ch, CURLINFO_HEADER_OUT, true);
         curl_setopt ($ch, CURLOPT_VERBOSE, true);
 


### PR DESCRIPTION
This allows self signed certs to be used correctly on remote systems
