### PR TITLE
Fixing "Illegal string offset 'messageid'"

### DIFF
--- a/lib/dbeng/dbeng_abs.php
+++ b/lib/dbeng/dbeng_abs.php
@@ -119,6 +119,9 @@ abstract class dbeng_abs {
 		$tmpList = '';
 
 		foreach($ar as $v) {
+			if (!isset($v[$val]) {
+				continue;
+			}
 			$tmpList .= $this->safe($v[$val], $forceType) . ",";
 		} # foreach
 		return substr($tmpList, 0, -1);


### PR DESCRIPTION
Current codebase throws the following warning:
**Warning**:  Illegal string offset 'messageid' in **/var/www/XXX/htdocs/lib/dbeng/dbeng_abs.php** on line **122**