### PR TITLE
Do not instantiate jQuery objects for tiptip anymore

### DIFF
--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -1,7 +1,7 @@
 $.address.init(function() {
 	$('.spotlink').address();
 }).externalChange(
-		function(event) {ao
+		function(event) {
 			basePATH = location.href.replace('#' + $.address.value(), '');
 			if ($.address.value() == '/' && basePATH.indexOf('/?page=getspot') < 0 && basePATH.indexOf('/details/') < 0) {
 				closeDetails(0);

--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -1,7 +1,7 @@
 $.address.init(function() {
 	$('.spotlink').address();
 }).externalChange(
-		function(event) {
+		function(event) {ao
 			basePATH = location.href.replace('#' + $.address.value(), '');
 			if ($.address.value() == '/' && basePATH.indexOf('/?page=getspot') < 0 && basePATH.indexOf('/details/') < 0) {
 				closeDetails(0);
@@ -1304,25 +1304,25 @@ function addSpotFilter(xsrf, filterType, filterValue, filterName, addElementClas
 } // addSpotFilter
 
 function applyTipTip(){
-	var categories = $(this).data('cats');
-	if(!categories) return;
-	var $dl = $("<ul/>");
-	var list = $.map(categories, function(value, key){
-		if(value) {
-			if(key=='image'){//if image is used, don't add text or :
-				return $("<li/>").append(value);
-			}
-			else{
-				return $("<li/>").append($("<strong/>").text(key + ": ")).append(value);
-			}
-		} else {
+        var categories = $(this).data('cats');
+        if(!categories) return;
+        var dl = "<ul>";
+        var list = $.map(categories, function(value, key){
+                if(value) {
+                        if(key=='image'){//if image is used, don't add text or :
+                                return '<li>' + value + '</li>';
+                        }
+                        else{
+                                return '<li><strong/>' + key + ': ' + value;
+                        }
+                } else {
             return '';
         } // else
-	});
+        });
 
-	$dl.append.apply($dl, list);
-	$(this).attr("title", "");
-	$(this).tipTip({defaultPosition: 'bottom', maxWidth: 'auto', content: $dl});
+        dl = dl + list + '</ul>';
+        $(this).attr("title", "");
+        $(this).tipTip({defaultPosition: 'bottom', delay: 800, maxWidth: 'auto', content: dl});
 }
 
 function findNearest(possibleValues, realValues, includeLeft, includeRight, value) {


### PR DESCRIPTION
By using an uglier way - adding raw HTML - we do not trigger the loading of the images up front, and thus prevent paying the preformance penalty of loading the page.

We also increase the default timeout of an image from 400 ms to 800 ms, this feels less responsive, but has the added benefit of not triggering loads of imageloads when just hovering over the list of spots.