### PR TITLE
Added SQLite option to installer. Fixed SpotStruct for sqlite.

### DIFF
--- a/install.php
+++ b/install.php
@@ -463,6 +463,16 @@
 
 					break;
 				} # pdo_pgsql 
+
+				case 'pdo_sqlite' : {
+					$dbConnectionString .= "\$dbsettings['engine'] = 'pdo_sqlite';" . PHP_EOL;
+					$dbConnectionString .= "\$dbsettings['host'] = '" . $_SESSION['spotsettings']['db']['host'] . "';" . PHP_EOL;
+					$dbConnectionString .= "\$dbsettings['dbname'] = '" . $_SESSION['spotsettings']['db']['dbname'] . "';" . PHP_EOL;
+					$dbConnectionString .= "\$dbsettings['user'] = '" . $_SESSION['spotsettings']['db']['user'] . "';" . PHP_EOL;
+					$dbConnectionString .= "\$dbsettings['pass'] = '" . $_SESSION['spotsettings']['db']['pass'] . "';" . PHP_EOL;
+
+					break;
+				} # pdo_sqlite
 			} # switch
 
 			# Try to create the dbsettings.inc.php file for the user

--- a/lib/dao/Dao_Factory.php
+++ b/lib/dao/Dao_Factory.php
@@ -122,6 +122,7 @@ abstract class Dao_Factory {
 			case 'postgresql'			: return new Dao_Postgresql_Factory(); break;
             case 'pdo_mysql' 	        :
 			case 'mysql'				: return new Dao_Mysql_Factory(); break;
+            case 'pdo_sqlite' 	        :
 			case 'sqlite'				: return new Dao_Sqlite_Factory(); break;
 
 			default						: throw new Exception("Unknown DAO factory specified");

--- a/lib/dbstruct/SpotStruct_sqlite.php
+++ b/lib/dbstruct/SpotStruct_sqlite.php
@@ -23,6 +23,17 @@ class SpotStruct_sqlite extends SpotStruct_abs {
 	} # analyze
 
 	/*
+	 * Returns a database specific representation of a boolean value
+	 */
+	function bool2dt($b) {
+		if ($b) {
+			return '1';
+		} # if
+
+		return '0';
+	} # bool2dt
+
+	/*
 	 * Converts a 'spotweb' internal datatype to a 
 	 * database specific datatype
 	 */
@@ -105,6 +116,10 @@ class SpotStruct_sqlite extends SpotStruct_abs {
 		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_insert AFTER INSERT ON " . $tablename . " FOR EACH ROW
 								BEGIN
 								   INSERT INTO " . $ftsname . "(rowid," . implode(',', $colList) . ") VALUES (new.rowid, new." . implode(', new.', $colList) . ");
+								END");
+		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_delete AFTER DELETE ON " . $tablename . " FOR EACH ROW
+								BEGIN
+								   DELETE FROM " . $ftsname . " WHERE rowid=old.rowid;
 								END");
 	} # createFts
 	

--- a/templates/installer/step-002.inc.php
+++ b/templates/installer/step-002.inc.php
@@ -2,7 +2,7 @@
 			<table summary="PHP settings">
 				<tr> <th> Database settings </th> <th> </th> </tr>
 				<tr> <td colspan='2'> Spotweb needs an available MySQL or PostgreSQL database. The database needs to be created and you need to have an user account and password for this database. </td> </tr>
-				<tr> <td> type </td> <td> <select name='dbform[engine]'> <option value='pdo_mysql'>mysql</option> <option value='pdo_pgsql'>PostgreSQL</option> </select> </td> </tr>
+				<tr> <td> type </td> <td> <select name='dbform[engine]'> <option value='pdo_mysql'>mysql</option> <option value='pdo_pgsql'>PostgreSQL</option> <option value='pdo_sqlite'>SQLite (untested)</option> </select> </td> </tr>
 				<tr> <td> server </td> <td> <input type='text' length='40' name='dbform[host]' value='<?php echo htmlspecialchars($form['host']); ?>'></input> </td> </tr>
 				<tr> <td> database </td> <td> <input type='text' length='40' name='dbform[dbname]' value='<?php echo htmlspecialchars($form['dbname']); ?>' ></input></td> </tr>
 				<tr> <td> username </td> <td> <input type='text' length='40' name='dbform[user]' value='<?php echo htmlspecialchars($form['user']); ?>'></input> </td> </tr>


### PR DESCRIPTION
The [INSTALL](../blob/master/INSTALL) file mentioned (untested) SQLite support but the installer didn't know about it. So I added it and fixed the remaining bits.

n.b.: The folder containing the sqlite file has to be writable for the web server process otherwise you'll get a "Unable to open database file" error.

I got a "constraint error" halfway through the initial retrieve process. Turned out to be an inconsistency between the `spots` and the `idx_fts_spots` table, that's why I added the DELETE trigger.

If the `retrieve.php` times out during statistics creation, increase the `set_time_limit(60)` in `Services_Providers_Statistics.php:33`. I had to do that on my RasPi 2.