### PR TITLE
Fixed the infinite scroll when zoom is enabled

### DIFF
--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -168,7 +168,7 @@ function attachInfiniteScroll() {
 	$(window).scroll(function() {
 		var url = '?direction=next&data[spotsonly]=1&pagenr='+pagenr+$('#getURL').val()+' #spots';
 
-		if($(document).scrollTop() >= $(document).height() - $(window).height() && $(document).height() >= $(window).height() && pagenr > 0 && $("#overlay").is(':hidden')) {
+		if(Math.ceil($(document).scrollTop()) >= $(document).height() - $(window).height() && $(document).height() >= $(window).height() && pagenr > 0 && $("#overlay").is(':hidden')) {
 			if(!($("div.spots").hasClass("full"))) {
 				var scrollLocation = $("div.container").scrollTop();
 				$("#overlay").show().addClass('loading');


### PR DESCRIPTION
Added Math.ceil to round the scrollTop() value up because when zoom is enabled the amounts don't match exactly because the scrollTop() function returns a decimal number (15.5) which does'nt exactly match the compared value ($(document).height() - $(window).height()).