### PR TITLE
Fix old style (php4) constructors

### DIFF
--- a/NNTP/Client.php
+++ b/NNTP/Client.php
@@ -124,9 +124,9 @@ class Net_NNTP_Client extends Net_NNTP_Protocol_Client
      *
      * @access public
      */
-    function Net_NNTP_Client()
+    function __construct()
     {
-    	parent::Net_NNTP_Protocol_Client();
+    	parent::__construct(); //Net_NNTP_Protocol_Client();
     }
 
     // }}}

--- a/NNTP/Protocol/Client.php
+++ b/NNTP/Protocol/Client.php
@@ -164,7 +164,8 @@ class Net_NNTP_Protocol_Client
      *
      * @access public
      */
-    function Net_NNTP_Protocol_Client() {
+    function __construct()
+    {
 
     	//
 //    	parent::PEAR('Net_NNTP_Error');

--- a/vendor/pchart/pData.class.php
+++ b/vendor/pchart/pData.class.php
@@ -66,7 +66,7 @@
                         "7"=>array("R"=>224,"G"=>176,"B"=>46,"Alpha"=>100));
 
    /* Class creator */
-   function pData()
+   function __construct()
     {
      $this->Data = "";
      $this->Data["XAxisDisplay"]	= AXIS_FORMAT_DEFAULT;

--- a/vendor/pchart/pImage.class.php
+++ b/vendor/pchart/pImage.class.php
@@ -82,7 +82,7 @@
    var $LastChartLayout	= CHART_LAST_LAYOUT_REGULAR;	// Last layout : regular or stacked
 
    /* Class constructor */
-   function pImage($XSize,$YSize,$DataSet=NULL,$TransparentBackground=FALSE)
+   function __construct($XSize,$YSize,$DataSet=NULL,$TransparentBackground=FALSE)
     {
      $this->TransparentBackground = $TransparentBackground;
 

--- a/vendor/pchart/pPie.class.php
+++ b/vendor/pchart/pPie.class.php
@@ -36,7 +36,7 @@
    var $LabelPos = "" ;
 
    /* Class creator */
-   function pPie($Object,$pDataObject)
+   function __construct($Object,$pDataObject)
     {
      /* Cache the pChart object reference */
      $this->pChartObject = $Object;

--- a/vendor/phpseclib/Crypt/Hash.php
+++ b/vendor/phpseclib/Crypt/Hash.php
@@ -144,7 +144,7 @@ class Crypt_Hash {
      * @return Crypt_Hash
      * @access public
      */
-    function Crypt_Hash($hash = 'sha1')
+    function __construct($hash = 'sha1')
     {
         if ( !defined('CRYPT_HASH_MODE') ) {
             switch (true) {

--- a/vendor/phpseclib/Crypt/RSA.php
+++ b/vendor/phpseclib/Crypt/RSA.php
@@ -443,7 +443,7 @@ class Crypt_RSA {
      * @return Crypt_RSA
      * @access public
      */
-    function Crypt_RSA()
+    function __construct()
     {
         if ( !defined('CRYPT_RSA_MODE') ) {
             switch (true) {

--- a/vendor/phpseclib/Math/BigInteger.php
+++ b/vendor/phpseclib/Math/BigInteger.php
@@ -267,7 +267,7 @@ class Math_BigInteger {
      * @return Math_BigInteger
      * @access public
      */
-    function Math_BigInteger($x = 0, $base = 10)
+    function __construct($x = 0, $base = 10)
     {
         if ( !defined('MATH_BIGINTEGER_MODE') ) {
             switch (true) {


### PR DESCRIPTION
Spotweb runs php7 without any problems, however some warnings are given about depreciation of old style constructors

https://wiki.php.net/rfc/remove_php4_constructors