### PR TITLE
Implement multiple cache stores

### DIFF
--- a/lib/Bootstrap.php
+++ b/lib/Bootstrap.php
@@ -39,7 +39,7 @@ class Bootstrap {
          * Set the cache path
          */
         if ($settings->exists('cache_path')) {
-            $daoFactory->setCachePath($settings->get('cache_path'));
+            $daoFactory->setCacheStore(new Dao_Base_ZipCacheStore($settings->get('cache_path')));
         } # if
 
 		/*

--- a/lib/dao/Base/Dao_Base_Cache.php
+++ b/lib/dao/Base/Dao_Base_Cache.php
@@ -1,19 +1,15 @@
 <?php
 class Dao_Base_Cache implements Dao_Cache {
-    private     $_cachePath     = '';
     protected   $_conn;
+    protected   $_cacheStore    = null;
 
 	/*
 	 * constructs a new Dao_Base_Cache object,
 	 * connection object is given
 	 */
-	public function __construct(dbeng_abs $conn, $cachePath) {
+	public function __construct(dbeng_abs $conn, Dao_CacheStore $cacheStore) {
 		$this->_conn = $conn;
-        $this->_cachePath = $cachePath;
-
-        if (empty($this->_cachePath)) {
-            throw new NotImplementedException("Cache path is null?");
-        } # if
+		$this->_cacheStore = $cacheStore;
 	} # ctor
 
 	/*
@@ -68,254 +64,8 @@ class Dao_Base_Cache implements Dao_Cache {
         /*
          * Remove the item from disk and ignore any errors
          */
-        $filePath = $this->calculateFilePath($cacheId, $cachetype, $metaData);
-        @unlink($filePath);
+	$this->_cacheStore->removeCacheItem($cacheId, $cachetype, $metaData);
     } # removeCacheItem
-
-    /*
-     * Previous 'calculate file path' feature
-     */
-    protected function oldCalculateFilePath($cacheId, $cacheType, $metadata) {
-        /*
-         * Get the cache id
-         */
-        $cacheRow = $this->_conn->singleQuery("SELECT resourceid FROM cache WHERE id = :cacheid",
-            array(
-                ':cacheid' => array($cacheId, PDO::PARAM_INT)
-            ));
-        $resourceId = $cacheRow;
-
-        $filePath = $this->_cachePath . DIRECTORY_SEPARATOR;
-
-        switch ($cacheType) {
-            case Dao_Cache::SpotImage           : $filePath .= 'image' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::SpotNzb             : $filePath .= 'nzb' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::Statistics          : $filePath .= 'stats' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::Web                 : $filePath .= 'web' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::TranslaterToken     : $filePath .= 'translatertoken' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::TranslatedComments  : $filePath .= 'translatedcomments' . DIRECTORY_SEPARATOR; break;
-
-            default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
-        } # switch
-
-        /*
-         * We calculate SHA1 of it, to make sure we only use
-         * filesystem save and unique characters in the filename,
-         * a bit useless because the resourceId is already unique for
-         * the given storage type
-         */
-        $storageId = sha1($resourceId);
-        for($i = 0; $i < (strlen($storageId) - 4); $i += 3) {
-            $filePath .= substr($storageId, $i, 3) . DIRECTORY_SEPARATOR;
-        } # for
-        $filePath .= substr($storageId, strlen($storageId) - 4);
-
-        /*
-         * And create an extension, because thats nicer.
-         */
-        if ($cacheType == Dao_Cache::SpotImage) {
-            switch($metadata['imagetype']) {
-                case IMAGETYPE_GIF          : $filePath .= '.gif'; break;
-                case IMAGETYPE_JPEG         : $filePath .= '.jpg'; break;
-                case IMAGETYPE_PNG          : $filePath .= '.png'; break;
-
-                default                     : $filePath .= '.image.' . $metadata['imagetype']; break;
-            } # switch
-        } else {
-            switch ($cacheType) {
-                case Dao_Cache::SpotNzb             : $filePath .= '.nzb'; break;
-                case Dao_Cache::Statistics          : $filePath .= '.stats'; break;
-                case Dao_Cache::Web                 : $filePath .= '.http'; break;
-                case Dao_Cache::TranslaterToken     : $filePath .= '.token'; break;
-                case Dao_Cache::TranslatedComments  : $filePath .= '.translatedcomments'; break;
-
-                default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
-            } # switch
-        } # else
-
-        return $filePath;
-    } # oldCalculateFilePath
-
-
-    /*
-     * Calculates the exact filepath given a storageid
-     */
-    protected function calculateFilePath($cacheId, $cacheType, $metadata) {
-        $filePath = $this->_cachePath . DIRECTORY_SEPARATOR;
-
-        switch ($cacheType) {
-            case Dao_Cache::SpotImage           : $filePath .= 'image' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::SpotNzb             : $filePath .= 'nzb' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::Statistics          : $filePath .= 'stats' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::Web                 : $filePath .= 'web' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::TranslaterToken     : $filePath .= 'translatertoken' . DIRECTORY_SEPARATOR; break;
-            case Dao_Cache::TranslatedComments  : $filePath .= 'translatedcomments' . DIRECTORY_SEPARATOR; break;
-
-            default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
-        } # switch
-
-        /*
-         * We want to store at most 1000 file in one directory,
-         * so we use this.
-         */
-        if (floor($cacheId/ 1000) > 1000) {
-            $filePath .= implode(DIRECTORY_SEPARATOR, str_split($cacheId, 3)) . DIRECTORY_SEPARATOR . $cacheId;
-        } else {
-            $filePath .= floor($cacheId / 1000) . DIRECTORY_SEPARATOR . $cacheId;
-        } # else
-
-        /*
-         * And create an extension, because thats nicer.
-         */
-        if ($cacheType == Dao_Cache::SpotImage) {
-            switch($metadata['imagetype']) {
-                case IMAGETYPE_GIF          : $filePath .= '.gif'; break;
-                case IMAGETYPE_JPEG         : $filePath .= '.jpg'; break;
-                case IMAGETYPE_PNG          : $filePath .= '.png'; break;
-
-                default                     : $filePath .= '.image.' . $metadata['imagetype']; break;
-            } # switch
-        } else {
-            switch ($cacheType) {
-                case Dao_Cache::SpotNzb             : $filePath .= '.nzb'; break;
-                case Dao_Cache::Statistics          : $filePath .= '.stats'; break;
-                case Dao_Cache::Web                 : $filePath .= '.http'; break;
-                case Dao_Cache::TranslaterToken     : $filePath .= '.token'; break;
-                case Dao_Cache::TranslatedComments  : $filePath .= '.translatedcomments'; break;
-
-                default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
-            } # switch
-        } # else
-
-        return $filePath;
-    } # calculateFilePath
-
-    /*
-     * Migrate the cache from one storage format to another
-     */
-    public function migrateCacheToNewStorage($cacheId, $cacheType, $metaData) {
-        /*
-         * Get the unique filepath
-         */
-        $filePath = $this->calculateFilePath($cacheId, $cacheType, $metaData);
-        if (file_exists($filePath)) {
-            return ;
-        } # if
-
-        $oldFilePath = $this->oldCalculateFilePath($cacheId, $cacheType, $metaData);
-
-        if (!file_exists($oldFilePath)) {
-            $this->_conn->exec("DELETE FROM cache WHERE id = :cacheid",
-                array(
-                    ':cacheid' => array($cacheId, PDO::PARAM_INT)
-                ));
-            @unlink($oldFilePath);
-
-            echo PHP_EOL . 'Cache is corrupt, could not find on-disk resource for: ' . $cacheId . ' ' . $oldFilePath . ' -> ' . $filePath . PHP_EOL;
-
-            return ;
-        } # if
-
-        /*
-         * Move the file
-         */
-        @mkdir(dirname($filePath), 0777, true);
-        @chmod(dirname($filePath), 0777); // mkdir's chmod is masked with umask()
-        rename($oldFilePath, $filePath);
-        @chmod($filePath, 0777);
-
-        /*
-         * and erase the old one, and try to
-         * remove the directory
-         */
-        @unlink($oldFilePath);
-    } # migrateCacheToNewStorage
-
-    /*
-     * Returns the actual contents for a given resourceid
-     */
-    public function getCacheContent($cacheId, $cacheType, $metaData) {
-        /*
-         * Get the unique filepath
-         */
-        $filePath = $this->calculateFilePath($cacheId, $cacheType, $metaData);
-        $cacheContent = @file_get_contents($filePath);
-
-        if ($cacheContent === false) {
-            /*
-             * It might be the file is stored using the old way,
-             * if it is, move the file.
-             */
-            $oldFilePath = $this->oldCalculateFilePath($cacheId, $cacheType, $metaData);
-            if (@file_exists($oldFilePath)) {
-                $this->migrateCacheToNewStorage($cacheId, $cacheType, $metaData);
-            } else {
-                $this->removeCacheItem($cacheId, $cacheType, $metaData);
-
-                throw new CacheIsCorruptException('Cache is corrupt, could not find on-disk resource for: ' . $cacheId . ' ' . $oldFilePath . ' -> ' . $filePath);
-            } # if
-        } # if
-
-        return $cacheContent;
-    } # getCacheContent
-
-    /*
-     * Stores the actual content for a given resourceid
-     */
-    public function putCacheContent($cacheId, $cacheType, $content, $metaData) {
-        /*
-           * Get the unique filepath
-           */
-        $filePath = $this->calculateFilePath($cacheId, $cacheType, $metaData);
-
-        /*
-         * Create the directory
-         */
-        $success = true;
-        if (!is_writable(dirname($filePath))) {
-            $success = @mkdir(dirname($filePath), 0777, true);
-            @chmod(dirname($filePath), 0777); // mkdir's chmod is masked with umask()
-        } # if
-
-        if ($success) {
-            $success = (file_put_contents($filePath, $content) === strlen($content));
-
-            if ($success) {
-                @chmod($filePath, 0777);
-            } # if
-        } # if
-
-        if (!$success) {
-            /*
-             * Gather some diagnostics information to allow the operator to
-             * troubleshoot this easier.
-             */
-            $filePerms = fileperms(dirname($filePath));
-            $fileOwner = fileowner(dirname($filePath));
-            $fileGroup = filegroup(dirname($filePath));
-            $phpUser = get_current_user(); // appears to work for windows
-
-
-            if (function_exists('posix_getpwuid')) {
-                $fileGroup = posix_getgrgid($fileGroup);
-                $fileGroup = $fileGroup['name'];
-
-                $fileOwner = posix_getpwuid($fileOwner);
-                $fileOwner = $fileOwner['name'];
-
-                $phpUser = posix_getpwuid(posix_geteuid());
-                $phpUser = $phpUser['name'];
-            } # if
-
-            error_log('Unable to write to cache directory (' . $filePath . '), ' .
-                            ' owner=' . $fileOwner . ', ' .
-                            ' group=' . $fileGroup . ', ' .
-                            ' thisUser=' . $phpUser . ', ' .
-                            ' perms= ' . substr(decoct($filePerms), 2) );
-        } # if
-
-        return $success;
-    } # putCacheContent
 
 	/*
 	 * Returns the resource from the cache table, if we have any
@@ -340,8 +90,15 @@ class Dao_Base_Cache implements Dao_Cache {
             } # if
 
             $tmp[0]['metadata'] = unserialize($tmp[0]['metadata']);
-            $tmp[0]['content'] = $this->getCacheContent($tmp[0]['id'], $cachetype, $tmp[0]['metadata']);
-			return $tmp[0];
+
+	    try {
+            	$tmp[0]['content'] = $this->_cacheStore->getCacheContent($tmp[0]['id'], $cachetype, $tmp[0]['metadata']);
+				return $tmp[0];
+	    } catch(CacheIsCorruptException $x) {
+		$this->removeCacheItem($tmp[0]['id'], $cachetype, false);
+		throw $x;
+	    } // catch
+	
 		} # if
 
         // echo 'Cache miss for resourceid: ' . $resourceid . PHP_EOL;
@@ -391,7 +148,7 @@ class Dao_Base_Cache implements Dao_Cache {
         /*
          * Actually store the contents on disk
          */
-        if (!$this->putCacheContent($cacheRow, $cachetype, $content, $metadata)) {
+        if (!$this->_cacheStore->putCacheContent($cacheRow, $cachetype, $content, $metadata)) {
             /*
              * If we couldn't store the cache result, we have to actually remove the
              * cache record again
@@ -490,7 +247,16 @@ class Dao_Base_Cache implements Dao_Cache {
 	 * Retrieve a image resource from the cache
 	 */
 	function getCachedSpotImage($resourceId) {
-		return $this->getCache($resourceId, $this::SpotImage);
+		$tmpData = $this->getCache($resourceId, $this::SpotImage);
+
+        /*
+         * We need to 'migrate' the older cache format to this one
+         */
+        if (($tmpData !== false) && (!isset($tmpData['metadata']['dimensions']))) {
+            $tmpData['metadata'] = array('dimensions' => $tmpData['metadata'], 'isErrorImage' => false);
+        } // if
+
+        return $tmpData;
 	} # getCachedSpotImage
 
     /*
@@ -510,13 +276,14 @@ class Dao_Base_Cache implements Dao_Cache {
 	/*
 	 * Save an image resource into the cache
 	 */
-	function saveSpotImageCache($resourceId, $metadata, $content, $performExpire) {
+	function saveSpotImageCache($resourceId, $metadata, $content, $isErrorImage, $performExpire) {
         if ($performExpire) {
-            $ttl = 7 * 24 * 60 * 60;
+            $ttl = 1 * 60 * 60;
         } else {
             $ttl = 0;
         } # else
 
+        $metadata = array('dimensions' => $metadata, 'isErrorImage' => $isErrorImage);
 		return $this->saveCache($resourceId, $this::SpotImage, $metadata, $ttl, $content);
 	} # saveSpotImagecache
 
@@ -619,7 +386,7 @@ class Dao_Base_Cache implements Dao_Cache {
 
         # Prepare a list of values
         $idList = array();
-        $msgIdList = $this->_conn->arrayValToIn($resourceIdList, 'Message-ID');
+        $msgIdList = $this->_conn->arrayValToIn($resourceIdList, 'Message-ID', PDO::PARAM_STR);
 
         $rs = $this->_conn->arrayQuery("SELECT resourceid, cachetype
                                             FROM cache
@@ -637,5 +404,3 @@ class Dao_Base_Cache implements Dao_Cache {
     } # getMassCacheRecords
 
 } # Dao_Base_Cache
-
-

--- a/lib/dao/Base/Dao_Base_Factory.php
+++ b/lib/dao/Base/Dao_Base_Factory.php
@@ -2,19 +2,10 @@
 
  class Dao_Base_Factory extends Dao_Factory {
 
-     /*
-      * Actual cachepath to use
-      */
-     public function setCachePath($cachePath) {
-         throw new NotImplementedException();
-     } # setCachePath
-
-     /*
-      * Returns the currently configured cachepath
-      */
-     public function getCachePath() {
-         throw new NotImplementedException();
-     } # getCachePath
+     public function setCacheStore(Dao_CacheStore $cacheStore, $cachePath) {
+       throw new NotImplementedException();
+     } # setCacheStore
+ 
 
  	/*
  	 * Actual connection object to be used in
@@ -43,7 +34,7 @@
 	} # getUserDao
 
 	public function getCacheDao() {
-		return new Dao_Base_Cache($this->_conn, $this->_cachePath);
+		return new Dao_Base_Cache($this->_conn, $this->_cacheStore);
 	} # getCacheDao
 
 	public function getAuditDao() {

--- a/lib/dao/Base/Dao_Base_FlatCacheStore.php
+++ b/lib/dao/Base/Dao_Base_FlatCacheStore.php
@@ -1,0 +1,161 @@
+<?php
+
+class Dao_Base_FlatCacheStore implements Dao_CacheStore {
+	private     $_cachePath     = '';
+
+    public function __construct($cachePath) {
+	$this->_cachePath = $cachePath;
+
+        if (empty($this->_cachePath)) {
+            throw new NotImplementedException("Cache path is null?");
+        } # if
+    } # ctor
+
+    /*
+     * Removes an item from the cache
+     */
+    public function removeCacheItem($cacheId, $cachetype, $metaData) {
+        $filePath = $this->calculateFilePath($cacheId, $cachetype, $metaData);
+        @unlink($filePath);
+    } # removeCacheItem
+
+
+    /*
+     * Calculates the exact filepath given a storageid
+     */
+    protected function calculateFilePath($cacheId, $cacheType, $metadata) {
+        $filePath = $this->_cachePath . DIRECTORY_SEPARATOR;
+
+        switch ($cacheType) {
+            case Dao_Cache::SpotImage           : $filePath .= 'image' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::SpotNzb             : $filePath .= 'nzb' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Statistics          : $filePath .= 'stats' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Web                 : $filePath .= 'web' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslaterToken     : $filePath .= 'translatertoken' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslatedComments  : $filePath .= 'translatedcomments' . DIRECTORY_SEPARATOR; break;
+
+            default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+        } # switch
+
+        /*
+         * We want to store at most 1000 file in one directory,
+         * so we use this.
+         */
+        if (floor($cacheId/ 1000) > 1000) {
+            $filePath .= implode(DIRECTORY_SEPARATOR, str_split($cacheId, 3)) . DIRECTORY_SEPARATOR . $cacheId;
+        } else {
+            $filePath .= floor($cacheId / 1000) . DIRECTORY_SEPARATOR . $cacheId;
+        } # else
+
+        /*
+         * And create an extension, because thats nicer.
+         */
+        if ($cacheType == Dao_Cache::SpotImage) {
+            /*
+             * We need to 'migrate' the older cache format to this one
+             */
+            if (($metadata !== false) && (!isset($metadata['dimensions']))) {
+                $metadata = array('dimensions' => $metadata, 'isErrorImage' => false);
+            } // if
+
+            switch($metadata['dimensions']['imagetype']) {
+                case IMAGETYPE_GIF          : $filePath .= '.gif'; break;
+                case IMAGETYPE_JPEG         : $filePath .= '.jpg'; break;
+                case IMAGETYPE_PNG          : $filePath .= '.png'; break;
+
+                default                     : $filePath .= '.image.' . $metadata['dimensions']['imagetype']; break;
+            } # switch
+        } else {
+            switch ($cacheType) {
+                case Dao_Cache::SpotNzb             : $filePath .= '.nzb'; break;
+                case Dao_Cache::Statistics          : $filePath .= '.stats'; break;
+                case Dao_Cache::Web                 : $filePath .= '.http'; break;
+                case Dao_Cache::TranslaterToken     : $filePath .= '.token'; break;
+                case Dao_Cache::TranslatedComments  : $filePath .= '.translatedcomments'; break;
+
+                default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+            } # switch
+        } # else
+
+        return $filePath;
+    } # calculateFilePath
+
+    /*
+     * Returns the actual contents for a given resourceid
+     */
+    public function getCacheContent($cacheId, $cacheType, $metaData) {
+        /*
+         * Get the unique filepath
+         */
+        $filePath = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+        $cacheContent = @file_get_contents($filePath);
+
+        if ($cacheContent === false) {
+                $this->removeCacheItem($cacheId, $cacheType, $metaData);
+
+                throw new CacheIsCorruptException('Cache is corrupt, could not find on-disk resource for: ' . $cacheId . ' -> ' . $filePath);
+        } # if
+
+        return $cacheContent;
+    } # getCacheContent
+
+    /*
+     * Stores the actual content for a given resourceid
+     */
+    public function putCacheContent($cacheId, $cacheType, $content, $metaData) {
+        /*
+           * Get the unique filepath
+           */
+        $filePath = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+
+        /*
+         * Create the directory
+         */
+        $success = true;
+        if (!is_writable(dirname($filePath))) {
+            $success = @mkdir(dirname($filePath), 0777, true);
+            @chmod(dirname($filePath), 0777); // mkdir's chmod is masked with umask()
+        } # if
+
+        if ($success) {
+            $success = (file_put_contents($filePath, $content) === strlen($content));
+
+            if ($success) {
+                @chmod($filePath, 0777);
+            } # if
+        } # if
+
+        if (!$success) {
+            /*
+             * Gather some diagnostics information to allow the operator to
+             * troubleshoot this easier.
+             */
+            $filePerms = fileperms(dirname($filePath));
+            $fileOwner = fileowner(dirname($filePath));
+            $fileGroup = filegroup(dirname($filePath));
+            $phpUser = get_current_user(); // appears to work for windows
+
+
+            if (function_exists('posix_getpwuid')) {
+                $fileGroup = posix_getgrgid($fileGroup);
+                $fileGroup = $fileGroup['name'];
+
+                $fileOwner = posix_getpwuid($fileOwner);
+                $fileOwner = $fileOwner['name'];
+
+                $phpUser = posix_getpwuid(posix_geteuid());
+                $phpUser = $phpUser['name'];
+            } # if
+
+            error_log('Unable to write to cache directory (' . $filePath . '), ' .
+                            ' owner=' . $fileOwner . ', ' .
+                            ' group=' . $fileGroup . ', ' .
+                            ' thisUser=' . $phpUser . ', ' .
+                            ' perms= ' . substr(decoct($filePerms), 2) );
+        } # if
+
+        return $success;
+    } # putCacheContent
+
+
+}  # Dao_Base_CacheStore

--- a/lib/dao/Base/Dao_Base_ZipCacheStore.php
+++ b/lib/dao/Base/Dao_Base_ZipCacheStore.php
@@ -1,0 +1,164 @@
+<?php
+
+class Dao_Base_ZipCacheStore implements Dao_CacheStore {
+	private     $_cachePath     = '';
+
+    public function __construct($cachePath) {
+	$this->_cachePath = $cachePath;
+
+        if (empty($this->_cachePath)) {
+            throw new NotImplementedException("Cache path is null?");
+        } # if
+    } # ctor
+
+    /*
+     * Removes an item from the cache
+     */
+    public function removeCacheItem($cacheId, $cachetype, $metaData) {
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cachetype, $metaData);
+
+	$zip = new ZipArchive();
+	if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+		throw new CacheIsCorruptException('Unable to open ZIP file');
+	} // if
+	$zip->deleteName($fileName);
+	$zip->close();
+    } # removeCacheItem
+
+
+    /*
+     * Calculates the exact filepath given a storageid
+     */
+    protected function calculateFilePath($cacheId, $cacheType, $metadata) {
+        $filePath = $this->_cachePath . DIRECTORY_SEPARATOR;
+
+        switch ($cacheType) {
+            case Dao_Cache::SpotImage           : $filePath .= 'image' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::SpotNzb             : $filePath .= 'nzb' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Statistics          : $filePath .= 'stats' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Web                 : $filePath .= 'web' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslaterToken     : $filePath .= 'translatertoken' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslatedComments  : $filePath .= 'translatedcomments' . DIRECTORY_SEPARATOR; break;
+
+            default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+        } # switch
+	$zipName = $filePath;
+
+        /*
+         * We want to store at most 1000 file in one directory,
+         * so we use this.
+         */
+        if (floor($cacheId/ 1000) > 1000) {
+	    $cacheSeperated = str_split($cacheId, 3);
+
+	    $filePath .= implode(DIRECTORY_SEPARATOR, $cacheSeperated);
+
+	    $cacheSeperated = array_splice($cacheSeperated, 0, -1);
+            $zipName .= implode(DIRECTORY_SEPARATOR, $cacheSeperated) . '.zip';
+        } else {
+            $filePath .= floor($cacheId / 1000);
+	    $zipName .= floor($cacheId / 1000) . '.zip';
+        } # else
+
+        /*
+         * And create an extension, because thats nicer.
+         */
+	$extension = '';
+        if ($cacheType == Dao_Cache::SpotImage) {
+            /*
+             * We need to 'migrate' the older cache format to this one
+             */
+            if (($metadata !== false) && (!isset($metadata['dimensions']))) {
+                $metadata = array('dimensions' => $metadata, 'isErrorImage' => false);
+            } // if
+
+            switch($metadata['dimensions']['imagetype']) {
+                case IMAGETYPE_GIF          : $extension = '.gif'; break;
+                case IMAGETYPE_JPEG         : $extension = '.jpg'; break;
+                case IMAGETYPE_PNG          : $extension = '.png'; break;
+
+                default                     : $extension = '.image.' . $metadata['dimensions']['imagetype']; break;
+            } # switch
+        } else {
+            switch ($cacheType) {
+                case Dao_Cache::SpotNzb             : $extension = '.nzb'; break;
+                case Dao_Cache::Statistics          : $extension = '.stats'; break;
+                case Dao_Cache::Web                 : $extension = '.http'; break;
+                case Dao_Cache::TranslaterToken     : $extension = '.token'; break;
+                case Dao_Cache::TranslatedComments  : $extension = '.translatedcomments'; break;
+
+                default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+            } # switch
+        } # else
+
+	// 1st element is ZIP name, 2nd is file to include in it
+        return [$zipName, $cacheId . $extension, $filePath];
+    } # calculateFilePath
+
+    /*
+     * Returns the actual contents for a given resourceid
+     */
+    public function getCacheContent($cacheId, $cacheType, $metaData) {
+        /*
+         * Get the unique filepath
+         */
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+
+        $zip = new ZipArchive();
+        if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+                throw new CacheIsCorruptException('Unable to open ZIP file');
+        } // if
+        $cacheContent = $zip->getFromName($fileName);
+        $zip->close();
+
+	if ($cacheContent === false) {
+		// try to see if we have the original file, ... ?
+		if (is_readable($subFolder . DIRECTORY_SEPARATOR . $fileName)) {
+			$cacheContent = file_get_contents($subFolder . DIRECTORY_SEPARATOR . $fileName);
+
+			// write it to the ZIP file
+			$this->putCacheContent($cacheId, $cacheType, $cacheContent, $metaData);
+
+			// and remove it from disk
+			@unlink($subFolder . DIRECTORY_SEPARATOR . $fileName);
+		} else {
+            		$this->removeCacheItem($cacheId, $cacheType, $metaData);
+            		throw new CacheIsCorruptException('ZipCacheStore: Cache is corrupt, could not find on-disk resource for: ' . $cacheId . ' -> ' . $subFolder . DIRECTORY_SEPARATOR . $fileName);
+		} // else
+        } # if
+
+        return $cacheContent;
+    } # getCacheContent
+
+    /*
+     * Stores the actual content for a given resourceid
+     */
+    public function putCacheContent($cacheId, $cacheType, $content, $metaData) {
+        /*
+           * Get the unique filepath
+           */
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+
+        /*
+	 * Create the directory
+         */
+        $success = true;
+        if (!is_writable(dirname($zipName))) {
+            $success = @mkdir(dirname($zipName), 0777, true);
+            @chmod(dirname($zipName), 0777); // mkdir's chmod is masked with umask()
+        } # if
+
+        $zip = new ZipArchive();
+        if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+                throw new CacheIsCorruptException('Unable to open ZIP file');
+        } // if
+        $zip->addFromString($fileName, $content);
+        $zip->close();
+
+        @chmod($zipName, 0777); // mkdir's chmod is masked with umask()
+
+        return true;
+    } # putCacheContent
+
+
+}  # Dao_Base_CacheStore

--- a/lib/dao/Dao_CacheStore.php
+++ b/lib/dao/Dao_CacheStore.php
@@ -1,0 +1,9 @@
+<?php
+
+interface Dao_CacheStore {
+        # function calculateFilePath($cacheId, $cacheType, $metadata);
+
+        function removeCacheItem($cacheId, $cachetype, $metaData);
+        function getCacheContent($cacheId, $cacheType, $metaData);
+        function putCacheContent($cacheId, $cacheType, $content, $metaData);
+}

--- a/lib/dao/Mysql/Dao_Mysql_Factory.php
+++ b/lib/dao/Mysql/Dao_Mysql_Factory.php
@@ -2,21 +2,15 @@
 
  class Dao_Mysql_Factory extends Dao_Factory {
      private $_conn;
-     private $_cachePath;
+     private $_cacheStore;
 
-    /*
-     * Actual cachepath to use
-     */
-    public function setCachePath($cachePath) {
-        $this->_cachePath = $cachePath;
-    } # setCachePath
+    public function setCacheStore(Dao_CacheStore $cacheStore) {
+        $this->_cacheStore = $cacheStore;
+    } # setCacheStore
 
-    /*
-     * Returns the currently configured cachepath
-     */
-    public function getCachePath() {
-        return $this->_cachePath;
-    } # getCachePath
+    public function setCacheStore(Dao_CacheStore $cacheStore) {
+        $this->_cacheStore = $cacheStore;
+    } # setCacheStore
 
  	/*
  	 * Actual connection object to be used in
@@ -43,7 +37,7 @@
 	} # getUserDao
 
 	public function getCacheDao() {
-		return new Dao_Mysql_Cache($this->_conn, $this->getCachePath());
+		return new Dao_Mysql_Cache($this->_conn, $this->getCacheStore());
 	} # getCacheDao
 
 	public function getAuditDao() {

--- a/lib/dao/Postgresql/Dao_Postgresql_Factory.php
+++ b/lib/dao/Postgresql/Dao_Postgresql_Factory.php
@@ -2,21 +2,15 @@
 
  class Dao_Postgresql_Factory extends Dao_Factory {
  	private $_conn;
-    private $_cachePath;
+    private $_cacheStore;
 
-    /*
-     * Actual cachepath to use
-     */
-    public function setCachePath($cachePath) {
-        $this->_cachePath = $cachePath;
-    } # setCachePath
+    public function setCacheStore(Dao_CacheStore $cacheStore) {
+        $this->_cacheStore = $cacheStore;
+    } # setCacheStore
 
-    /*
-     * Returns the currently configured cachepath
-     */
-    public function getCachePath() {
-        return $this->_cachePath;
-    } # getCachePath
+    public function setCacheStore(Dao_CacheStore $cacheStore) {
+        $this->_cacheStore = $cacheStore;
+    } # setCacheStore
 
  	/*
  	 * Actual connection object to be used in
@@ -43,7 +37,7 @@
 	} # getUserDao
 
 	public function getCacheDao() {
-		return new Dao_Postgresql_Cache($this->_conn, $this->getCachePath());
+		return new Dao_Postgresql_Cache($this->_conn, $this->getCacheStore());
 	} # getCacheDao
 
 	public function getAuditDao() {

--- a/migrate-cache3.php
+++ b/migrate-cache3.php
@@ -1,0 +1,164 @@
+<?php
+
+class Dao_Base_ZipCacheStore implements Dao_CacheStore {
+	private     $_cachePath     = '';
+
+    public function __construct($cachePath) {
+	$this->_cachePath = $cachePath;
+
+        if (empty($this->_cachePath)) {
+            throw new NotImplementedException("Cache path is null?");
+        } # if
+    } # ctor
+
+    /*
+     * Removes an item from the cache
+     */
+    public function removeCacheItem($cacheId, $cachetype, $metaData) {
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cachetype, $metaData);
+
+	$zip = new ZipArchive();
+	if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+		throw new CacheIsCorruptException('Unable to open ZIP file');
+	} // if
+	$zip->deleteName($fileName);
+	$zip->close();
+    } # removeCacheItem
+
+
+    /*
+     * Calculates the exact filepath given a storageid
+     */
+    protected function calculateFilePath($cacheId, $cacheType, $metadata) {
+        $filePath = $this->_cachePath . DIRECTORY_SEPARATOR;
+
+        switch ($cacheType) {
+            case Dao_Cache::SpotImage           : $filePath .= 'image' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::SpotNzb             : $filePath .= 'nzb' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Statistics          : $filePath .= 'stats' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::Web                 : $filePath .= 'web' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslaterToken     : $filePath .= 'translatertoken' . DIRECTORY_SEPARATOR; break;
+            case Dao_Cache::TranslatedComments  : $filePath .= 'translatedcomments' . DIRECTORY_SEPARATOR; break;
+
+            default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+        } # switch
+	$zipName = $filePath;
+
+        /*
+         * We want to store at most 1000 file in one directory,
+         * so we use this.
+         */
+        if (floor($cacheId/ 1000) > 1000) {
+	    $cacheSeperated = str_split($cacheId, 3);
+
+	    $filePath .= implode(DIRECTORY_SEPARATOR, $cacheSeperated);
+
+	    $cacheSeperated = array_splice($cacheSeperated, 0, -1);
+            $zipName .= implode(DIRECTORY_SEPARATOR, $cacheSeperated) . '.zip';
+        } else {
+            $filePath .= floor($cacheId / 1000);
+	    $zipName .= floor($cacheId / 1000) . '.zip';
+        } # else
+
+        /*
+         * And create an extension, because thats nicer.
+         */
+	$extension = '';
+        if ($cacheType == Dao_Cache::SpotImage) {
+            /*
+             * We need to 'migrate' the older cache format to this one
+             */
+            if (($metadata !== false) && (!isset($metadata['dimensions']))) {
+                $metadata = array('dimensions' => $metadata, 'isErrorImage' => false);
+            } // if
+
+            switch($metadata['dimensions']['imagetype']) {
+                case IMAGETYPE_GIF          : $extension = '.gif'; break;
+                case IMAGETYPE_JPEG         : $extension = '.jpg'; break;
+                case IMAGETYPE_PNG          : $extension = '.png'; break;
+
+                default                     : $extension = '.image.' . $metadata['dimensions']['imagetype']; break;
+            } # switch
+        } else {
+            switch ($cacheType) {
+                case Dao_Cache::SpotNzb             : $extension = '.nzb'; break;
+                case Dao_Cache::Statistics          : $extension = '.stats'; break;
+                case Dao_Cache::Web                 : $extension = '.http'; break;
+                case Dao_Cache::TranslaterToken     : $extension = '.token'; break;
+                case Dao_Cache::TranslatedComments  : $extension = '.translatedcomments'; break;
+
+                default                         : throw new NotImplementedException("Undefined Cachetype: " . $cacheType);
+            } # switch
+        } # else
+
+	// 1st element is ZIP name, 2nd is file to include in it
+        return [$zipName, $cacheId . $extension, $filePath];
+    } # calculateFilePath
+
+    /*
+     * Returns the actual contents for a given resourceid
+     */
+    public function getCacheContent($cacheId, $cacheType, $metaData) {
+        /*
+         * Get the unique filepath
+         */
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+
+        $zip = new ZipArchive();
+        if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+                throw new CacheIsCorruptException('Unable to open ZIP file');
+        } // if
+        $cacheContent = $zip->getFromName($fileName);
+        $zip->close();
+
+	if ($cacheContent === false) {
+		// try to see if we have the original file, ... ?
+		if (is_readable($subFolder . DIRECTORY_SEPARATOR . $fileName)) {
+			$cacheContent = file_get_contents($subFolder . DIRECTORY_SEPARATOR . $fileName);
+
+			// write it to the ZIP file
+			$this->putCacheContent($cacheId, $cacheType, $cacheContent, $metaData);
+
+			// and remove it from disk
+			@unlink($subFolder . DIRECTORY_SEPARATOR . $fileName);
+		} else {
+            		$this->removeCacheItem($cacheId, $cacheType, $metaData);
+            		throw new CacheIsCorruptException('ZipCacheStore: Cache is corrupt, could not find on-disk resource for: ' . $cacheId . ' -> ' . $subFolder . DIRECTORY_SEPARATOR . $fileName);
+		} // else
+        } # if
+
+        return $cacheContent;
+    } # getCacheContent
+
+    /*
+     * Stores the actual content for a given resourceid
+     */
+    public function putCacheContent($cacheId, $cacheType, $content, $metaData) {
+        /*
+           * Get the unique filepath
+           */
+        list($zipName, $fileName, $subFolder) = $this->calculateFilePath($cacheId, $cacheType, $metaData);
+
+        /*
+	 * Create the directory
+         */
+        $success = true;
+        if (!is_writable(dirname($zipName))) {
+            $success = @mkdir(dirname($zipName), 0777, true);
+            @chmod(dirname($zipName), 0777); // mkdir's chmod is masked with umask()
+        } # if
+
+        $zip = new ZipArchive();
+        if ($zip->open($zipName, ZipArchive::CREATE) !== true) {
+                throw new CacheIsCorruptException('Unable to open ZIP file');
+        } // if
+        $zip->addFromString($fileName, $content);
+        $zip->close();
+
+        @chmod($zipName, 0777); // mkdir's chmod is masked with umask()
+
+        return true;
+    } # putCacheContent
+
+
+}  # Dao_Base_CacheStore


### PR DESCRIPTION
Just before the last major release of Spotweb, the cache was migrated from a database cache to a flat filestore cache.

This flat filestore caches in nested directories the actual files and stores the metadata on disk. While this is an improvement over abusing the database for this amount of data, it does take its toll on both diskspace as filesystem performance if you have a full Spotweb system.

Attached in this pull request are several parts: 
- Migrate the actual storing of the cache into a seperate cache store (interface Dao_Base_CacheStore)
- Implementation of the current FlatFile Cache Store
- Example implementation of a Zipped file store

The Zipped cache store stores up to 1000 files into a single ZIP file archive. While this is mostly not done for compression (eg: JPG's dont compress all that well, although NZB's do) it is mostly done to reduce the amount of inode's on the filesystem and to reduce the blocksize overhead of the filesystem. It's been runing for more than a year on my system and reduced the impact of the cache immensely.

The ZippedCacheStore piece is also the default in this pull request. An example script is provided which migrates the older cache store to the Zipped cache store.

---

ToDo:
- Test. test it properly. The original code is based on the mediainfo branch and i just copied and pasted into the Github web ui so i might have forgotton some parts.
- Apply this patch to the mediainfo branch as well.
- Make the cache store configureable from within the UI.
- Test the migration script properly.
- Make sure the actual cleanup of empty directories work.
