### PR TITLE
Fix for Notify My Android for PHP7

### DIFF
--- a/lib/notifications/nma/class.nma.php
+++ b/lib/notifications/nma/class.nma.php
@@ -27,7 +27,7 @@ class NotifyMyAndroid
 		'description' 	=> 		10000,	// Description of the event.
 	);
 	
-	function NotifyMyAndroid($apikey=null, $verify=false, $devkey=null, $proxy=null, $userpwd=null)
+	function __construct($apikey=null, $verify=false, $devkey=null, $proxy=null, $userpwd=null)
 	{
 		$curl_info = curl_version();	// Checks for cURL function and SSL version. Thanks Adrian Rollett!
 		if(!function_exists('curl_exec') || empty($curl_info['ssl_version']))


### PR DESCRIPTION
Fix for Notify My Android for PHP7. See changes for details.
Also fix for this issue: https://github.com/spotweb/spotweb/issues/124