### PR TITLE
Fix related to #66 and #83

### DIFF
--- a/lib/dbstruct/SpotStruct_abs.php
+++ b/lib/dbstruct/SpotStruct_abs.php
@@ -395,7 +395,7 @@ abstract class SpotStruct_abs {
 		# ---- reportsxover table ---- #
 		$this->createTable('reportsxover', "ascii"); 
 		$this->validateColumn('messageid', 'reportsxover', 'VARCHAR(128)', "''", true, 'ascii');
-		$this->validateColumn('fromhdr', 'reportsxover', 'VARCHAR(128)', "''", true, 'utf8');
+		$this->validateColumn('fromhdr', 'reportsxover', 'VARCHAR(256)', "''", true, 'utf8');
 		$this->validateColumn('keyword', 'reportsxover', 'VARCHAR(128)', "''", true, 'ascii');
 		$this->validateColumn('nntpref', 'reportsxover', 'VARCHAR(128)', "''", true, 'ascii');
 		$this->alterStorageEngine("reportsxover", "InnoDB");

--- a/templates/notifications/retriever_finished.inc.php
+++ b/templates/notifications/retriever_finished.inc.php
@@ -5,7 +5,7 @@ echo ($newSpotCount == 1) ? "is " . $newSpotCount . " spot" : "are " . $newSpotC
 if ($newCommentCount > 0) {
 	echo ($newReportCount > 0) ? ", " : " en ";
 	echo $newCommentCount;
-	echo ($newCommentCount == 1) ? " reaction" : " reactionss";
+	echo ($newCommentCount == 1) ? " reaction" : " reactions";
 } # if
 if ($newReportCount > 0) {
 	echo " and " . $newReportCount;


### PR DESCRIPTION
Avoids crash upon inserting reports with 'fromhdr' longer than 128 characters

```
Fatal error occured retrieving reports: 
 22001: 1406: Data too long for column 'fromhdr' at row 1
```
