### PR TITLE
Invert if statement for https check, better compatibility

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -29,7 +29,7 @@
  * in notifications to users.
  */
 if (isset($_SERVER['SERVER_PROTOCOL'])) {
-    $settings['spotweburl'] = (@$_SERVER['HTTPS'] == 'on' ? 'https' : 'http') . '://' . @$_SERVER['HTTP_HOST'] . (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']). '/' : '/');	
+    $settings['spotweburl'] = (@$_SERVER['HTTPS'] == 'off' ? 'http' : 'https') . '://' . @$_SERVER['HTTP_HOST'] . (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']). '/' : '/');	
 } else {
 	$settings['spotweburl'] = 'http://mijnuniekeservernaam/spotweb/';
 } # if


### PR DESCRIPTION
I inverted the https check for compatibility. On some setups it happens that $_SERVER['HTTPS'] is undefined or nil if it is turned on, but it is set to 'off' when using http. (this was the case for me)

This needs testing on some different machines (which I don't have), to validate if this works on all systems.