### PR TITLE
Make server base url scheme insensitive

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -29,7 +29,7 @@
  * in notifications to users.
  */
 if (isset($_SERVER['SERVER_PROTOCOL'])) {
-    $settings['spotweburl'] = (@$_SERVER['HTTPS'] == 'on' ? 'https' : 'http') . '://' . @$_SERVER['HTTP_HOST'] . (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']). '/' : '/');	
+    $settings['spotweburl'] = '//' . @$_SERVER['HTTP_HOST'] . (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']). '/' : '/');	
 } else {
 	$settings['spotweburl'] = 'http://mijnuniekeservernaam/spotweb/';
 } # if


### PR DESCRIPTION
Solves potential problems with reverse proxy offloading SSL
Tested on all major browsers (IE, FF, Chrome, Safari).

Fixes #176 
