### PR TITLE
Added Scrutinizer config.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,30 @@
+filter:
+    excluded_paths:
+        - 'tests/*'
+    dependency_paths:
+        - 'vendor/*'
+
+checks:
+    php: true
+    javascript: true
+
+tools:
+    php_analyzer: true
+    php_code_sniffer:
+        config:
+            standard: "PSR2"
+    php_cs_fixer:
+        enabled: true
+        config: { level: psr2 }
+    php_mess_detector: true
+    php_loc:
+        enabled: true
+        excluded_dirs: [vendor]
+
+build:
+    environment:
+        timezone: "Europe/Amsterdam"
+        php: "7.0"
+        mysql: false
+        postgresql: false
+        redis: false


### PR DESCRIPTION
This adds a basic configuration file for Scrutinizer CI, a free (for OpenSource projects) tool to analyse and rate code quality and give warnings about possible security issues. This looks like here: https://scrutinizer-ci.com/g/mbirth/spotweb/ .

When merged, you have to setup an account on https://scrutinizer-ci.com/ and add this repo.