### PR TITLE
Spotweb webroot detection

### DIFF
--- a/templates/installer/step-final.inc.php
+++ b/templates/installer/step-final.inc.php
@@ -27,7 +27,7 @@
 <tr>
     <td> &rarr; </td>
     <td>
-        <a href="/spotweb/">Visit your Spotweb</a>
+        <a href="<?php echo dirname($_SERVER['PHP_SELF']); ?>">Visit your Spotweb</a>
     </td>
 </tr>
 </table>


### PR DESCRIPTION
After installation you have a link to your "new" spotweb install, because I'm running on a subdomain I found out this was incorrect and hard coded. Changed this to a nice dynamic url which fixes this for everyone not running spotweb in a subfolder.
