### PR TITLE
Localization fixes 1

### DIFF
--- a/templates/we1rdo/includes/filters.inc.php
+++ b/templates/we1rdo/includes/filters.inc.php
@@ -185,7 +185,7 @@
 <?php						
 	}
 ?>
-						<h4>Sorteren op:</h4>
+						<h4><?php echo _('Sort on:'); ?></h4>
 						<input type="hidden" name="sortdir" value="<?php if($sortType == "stamp" || $sortType == "spotrating" || $sortType == "commentcount") {echo "DESC";} else {echo "ASC";} ?>">
 						<ul class="search sorting threecol">
 							<li> <input type="radio" name="sortby" value="" <?php echo $sortType == "" ? 'checked="checked"' : "" ?>><label><?php echo _('Relevance'); ?></label> </li>

--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -1387,7 +1387,7 @@ function initSliders() {
                 sliderMaxFileSize = fixedValues[1];
             } // else
 
-            $( "#human-filesize" ).text( "Tussen " + format_size( parseInt($( "#min-filesize").val().substring("filesize:>:DEF:".length)) ) + " en " + format_size( parseInt($( "#max-filesize").val().substring("filesize:>:DEF:".length) )) );
+            $( "#human-filesize" ).text( "Between " + format_size( parseInt($( "#min-filesize").val().substring("filesize:>:DEF:".length)) ) + " and " + format_size( parseInt($( "#max-filesize").val().substring("filesize:>:DEF:".length) )) );
 
             return false;
             }
@@ -1416,7 +1416,7 @@ function initSliders() {
     var nearestMax = findNearest(possibleValues, realValues, false, true, convertedSliderMaxFileSize);
     $( "#min-filesize" ).val( "filesize:>:DEF:" + nearestMin[1]);
     $( "#max-filesize" ).val( "filesize:<:DEF:" + nearestMax[1]);
-    $( "#human-filesize" ).text( "Tussen " + format_size( parseInt($( "#min-filesize").val().substring("filesize:>:DEF:".length)) ) + " en " + format_size( parseInt($( "#max-filesize").val().substring("filesize:>:DEF:".length) )) );
+    $( "#human-filesize" ).text( "Between " + format_size( parseInt($( "#min-filesize").val().substring("filesize:>:DEF:".length)) ) + " and " + format_size( parseInt($( "#max-filesize").val().substring("filesize:>:DEF:".length) )) );
 
     /* Report counts */
     var reportSlideValue = $( "#slider-reportcount" ).slider("values", 0);


### PR DESCRIPTION
Two localization fixes for spotweb.

The first is "Sort On:" in the search box and now uses the LC_MESSAGE text.

The second is in scripts.js and is now hard coded to English since there doesn't seem to be string resources setup.    The change is from the Dutch "Tussen" to "Between" and "en" to "and" for the size slider.