### PR TITLE
Another bugfix in retrieve.php

### DIFF
--- a/retrieve.php
+++ b/retrieve.php
@@ -3,6 +3,12 @@
 error_reporting(2147483647);
 
 try {
+	/*
+	 * If we are run from another directory, try to change the current
+	 * working directory to a directory the script is in
+	 */
+	chdir(__DIR__);
+
 	require_once __DIR__ . '/vendor/autoload.php';
 
 	/*


### PR DESCRIPTION
When running the script from outside the Spotweb directory, `Bootstrap::getDaoFactory()` wasn't able to include `dbsettings.inc.php` and `Bootstrap::getSettings()` wasn't able to require`settings.php`. So change working directory to directory where `retrieve.php` is located.