### PR TITLE
Fixed incorrect url for tweaknews (nl to eu)

### DIFF
--- a/usenetservers.xml
+++ b/usenetservers.xml
@@ -560,14 +560,14 @@
 
 		<server name='Tweaknews'>
 			<ssl>
-				<header ssl='yes' port='563'>news.tweaknews.nl</header>
-				<nzb ssl='yes' port='563'>news.tweaknews.nl</nzb>
-				<post ssl='yes' port='563'>news.tweaknews.nl</post>
+				<header ssl='yes' port='563'>news.tweaknews.eu</header>
+				<nzb ssl='yes' port='563'>news.tweaknews.eu</nzb>
+				<post ssl='yes' port='563'>news.tweaknews.eu</post>
 			</ssl>
 			<plain>
-				<header ssl='' port='119'>news.tweaknews.nl</header>
-				<nzb ssl='' port='119'>news.tweaknews.nl</nzb>
-				<post ssl='' port='119'>news.tweaknews.nl</post>
+				<header ssl='' port='119'>news.tweaknews.eu</header>
+				<nzb ssl='' port='119'>news.tweaknews.eu</nzb>
+				<post ssl='' port='119'>news.tweaknews.eu</post>
 			</plain>
 		</server>		
 


### PR DESCRIPTION
![bug](https://cloud.githubusercontent.com/assets/17547877/20041722/9cbaff7c-a46d-11e6-959b-3eb10230ef0d.PNG)

Because I used custom server all the time I never noticed this. After above error I went looking in the xml and noticed it used nl instead of eu for tweaknews.