### PR TITLE
Fixed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Spotweb
+# Spotweb
 Spotweb is a decentralized usenet community based on the [Spotnet](/spotnet/spotnet/wiki) protocol.
 
 Spotweb requires an operational webserver with PHP5 installed, it uses either an MySQL or an PostgreSQL database to store it's contents in. 
@@ -49,12 +49,12 @@ Please run 'install.php' from within your browser before attempting anything fur
 all items are checked 'OK'.
 
 ## Installation
-Installation is the toughest part of Spotweb. Depending on your platform you should look at the different tutorials available on the [Spotweb wiki](/spotweb/spotweb/wiki), but the basic steps are:
+Installation is the toughest part of Spotweb. Depending on your platform you should look at the different tutorials available on the [Spotweb wiki](https://github.com/spotweb/spotweb/wiki), but the basic steps are:
 
 1. Ensure you have an database server installed (MySQL, PostgreSQL or SQLite).
 2. Create an empty 'spotweb' database.
 3. Ensure you have a webserver running and PHP is configured for this webserver.
-4. [Download the Spotweb zip file.](/spotweb/spotweb/archive/master.zip)
+4. [Download the Spotweb zip file.](https://github.com/spotweb/spotweb/archive/master.zip)
 5. Unpack the zip file to a directory of choice.
 6. Open 'install.php' in your browser until everything is 'OK'. Fix the parts which aren't OK.
 7. Follow the wizard and perform the instructions as given by the wizard.


### PR DESCRIPTION
GitHub doesn't seem to render relative links properly, fixed by changing to absolute links. 