### PR TITLE
Long poster name breaks layout

### DIFF
--- a/templates/we1rdo/css/style.css
+++ b/templates/we1rdo/css/style.css
@@ -279,7 +279,7 @@ table.spots td.genre,
 table.spots th.genre {min-width:120px; width:120px;}
 table.spots td.poster,
 table.spots th.poster {min-width:110px; width:110px; overflow:hidden;}
-table.spots td.poster a {width:110px;}
+table.spots td.poster a {width:115px;}
 table.spots td.date,
 table.spots th.date {min-width:140px; width:140px;}
 table.spots td.filesize,


### PR DESCRIPTION
Added 5px to ensure that a long spotter name which is Whitelisted doesn't break the layout.
5px should be enough, 10px extra also works.