### PR TITLE
Fixes for SQLite

### DIFF
--- a/lib/dbeng/dbeng_pdo_sqlite.php
+++ b/lib/dbeng/dbeng_pdo_sqlite.php
@@ -15,6 +15,7 @@ class dbeng_pdo_sqlite extends dbeng_pdo {
 			if (!$this->_conn instanceof PDO) {
 				$this->_conn = new PDO('sqlite:' . $db);
 				$this->_conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+				$this->_conn->setAttribute(PDO::ATTR_TIMEOUT, 300);
 			} # if		
 		} catch(PDOException $e) {
 				throw new DatabaseConnectionException($e->getMessage(), -1);

--- a/lib/dbeng/dbfts_sqlite.php
+++ b/lib/dbeng/dbfts_sqlite.php
@@ -42,7 +42,8 @@ class dbfts_sqlite extends dbfts_abs {
 			 * ambiguity
 			 */
 			$tmpField = explode('.', $searchItem['fieldname']);
-			$matchList[] = $searchValue;
+			$field = $tmpField[1];
+			$matchList[] = $field . ':' . substr($this->_db->safe($searchValue), 1, -1);
 		} # foreach
 		
 		# add one WHERE MATCH conditions with all conditions

--- a/lib/services/Providers/Services_Providers_Statistics.php
+++ b/lib/services/Providers/Services_Providers_Statistics.php
@@ -30,7 +30,7 @@ class Services_Providers_Statistics {
 	public function createAllStatistics() {
 		foreach ($this->getValidStatisticsLimits() as $limitValue => $limitName) {
 			# Reset timelimit
-			set_time_limit(60);
+			set_time_limit(120);
 
 			foreach ($this->getValidStatisticsGraphs() as $graphValue => $graphName) {
 				$this->renderStatImage($graphValue, $limitValue);


### PR DESCRIPTION
These are the changes I had to make to my local installation to work with SQLite3 on a Raspberry Pi 2.

One thing was the storing of Spot sizes >2GB because `PARAM_INT` is only a 32bit signed integer on a 32bit system. All Spots larger than 2GB were shown as "2GB". But since SQLite doesn't care about types, sending the size as `PARAM_STR` is totally fine. (The `addSpots()` is a 1:1 copy of the one from Base with only the `PARAM_INT` for `filesize` changed into a `PARAM_STR`.)

Then there was the search which always matched against all fields. Also it had problems with special characters. Fixed by prefixing the field to search and escaping the entered term (+ removing quotes the escape function adds).

Finally I had to increase some timeout values to accommodate the rather slow Raspberry Pi 2 I have this running on.