### PR TITLE
Use FTS5 for SQLite. (Better performance than FTS4)

### DIFF
--- a/lib/dbeng/dbfts_sqlite.php
+++ b/lib/dbeng/dbfts_sqlite.php
@@ -48,7 +48,7 @@ class dbfts_sqlite extends dbfts_abs {
 		
 		# add one WHERE MATCH conditions with all conditions
 
-        $filterValueSql[] =  '(idx_fts_spots_'. $idxnum .'.docid = s.rowid) AND ' . " (idx_fts_spots_" . $idxnum . ".". $columnField . " MATCH '" . implode(' ', $matchList) . "') ";
+        $filterValueSql[] =  '(idx_fts_spots_'. $idxnum .'.rowid = s.rowid) AND ' . " (idx_fts_spots_" . $idxnum . ".". $columnField . " MATCH '" . implode(' ', $matchList) . "') ";
 		
 		SpotTiming::stop(__CLASS__ . '::' . __FUNCTION__, array($filterValueSql,$additionalTables));
 

--- a/lib/dbstruct/SpotStruct_sqlite.php
+++ b/lib/dbstruct/SpotStruct_sqlite.php
@@ -110,16 +110,14 @@ class SpotStruct_sqlite extends SpotStruct_abs {
 		$this->_dbcon->rawExec("DROP TRIGGER IF EXISTS " . $ftsname . "_insert");
 		
 		# and recreate the virtual table and link the update trigger to it
-		$this->_dbcon->rawExec("CREATE VIRTUAL TABLE " . $ftsname . " USING FTS4(CONTENT='spots'," . implode(',', $colList) . ", matchinfo=fts3)");
+		$this->_dbcon->rawExec("CREATE VIRTUAL TABLE " . $ftsname . " USING FTS5(CONTENT='spots'," . implode(',', $colList) . ", columnsize=0)");
 
 		$this->_dbcon->rawExec("INSERT INTO " . $ftsname . "(rowid, " . implode(',', $colList) . ") SELECT rowid," . implode(',', $colList) . " FROM " . $tablename);
-		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_insert AFTER INSERT ON " . $tablename . " FOR EACH ROW
-								BEGIN
+		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_insert AFTER INSERT ON " . $tablename . " BEGIN
 								   INSERT INTO " . $ftsname . "(rowid," . implode(',', $colList) . ") VALUES (new.rowid, new." . implode(', new.', $colList) . ");
 								END");
-		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_delete AFTER DELETE ON " . $tablename . " FOR EACH ROW
-								BEGIN
-								   DELETE FROM " . $ftsname . " WHERE rowid=old.rowid;
+		$this->_dbcon->rawExec("CREATE TRIGGER " . $ftsname . "_delete AFTER DELETE ON " . $tablename . " BEGIN
+								   INSERT INTO " . $ftsname . "(" . $ftsname . ",rowid," . implode(',', $colList) . ") VALUES('delete', old.rowid, old." . implode(', old.', $colList) . ");
 								END");
 	} # createFts
 	


### PR DESCRIPTION
FTS5 seems to be included in recent (=last few years) SQLite versions and it promises fixing all the problems with FTS4 (currently used in Spotweb), being more performant and requiring less disk space.

This PR changes the database struct to use FTS5 and it also fixes a deprecated thing with `docid` vs. `rowid`.