### PR TITLE
Fix call to addRecord() although logging is disabled and Logger was never initialised.

### DIFF
--- a/lib/SpotDebug.php
+++ b/lib/SpotDebug.php
@@ -20,6 +20,7 @@ class SpotDebug
     protected static function spotlevelToMonolevel($lvl)
     {
         switch ($lvl) {
+            case self::DISABLED:
             case self::TRACE:
                 return Logger::DEBUG;
             case self::DEBUG:
@@ -56,7 +57,9 @@ class SpotDebug
 
     public static function msg($lvl, $msg, $context = array())
     {
-        self::$_debugLogDao->addRecord(self::spotlevelToMonolevel($lvl), $msg, $context);
+        if (!is_null(self::$_debugLogDao)) {
+            self::$_debugLogDao->addRecord(self::spotlevelToMonolevel($lvl), $msg, $context);
+        }
     } # msg
 
 } # class SpotDebug


### PR DESCRIPTION
Just noticed a problem when using MySQL with debugging disabled. The SpotDebug class was trying to log a message to the Logger, but the Logger was never initialised (because `SpotDebug::disable()` was called, not `::enable(...)`).

This fixes that.