### PR TITLE
Removed reversestamp column from table and sorting.

### DIFF
--- a/lib/dao/Base/Dao_Base_Spot.php
+++ b/lib/dao/Base/Dao_Base_Spot.php
@@ -64,17 +64,6 @@ class Dao_Base_Spot implements Dao_Spot {
 		$sortList = array();
 		foreach($sortFields as $sortValue) {
 			if (!empty($sortValue)) {
-				/*
-                 * when asked to sort on the field 'stamp' descending, we secretly 
-                 * sort ascsending on a field called 'reversestamp'. Older MySQL versions
-                 * suck at sorting in reverse, and older NAS systems run ancient MySQl
-                 * versions
-                 */
-				if ((strtolower($sortValue['field']) == 's.stamp') && strtolower($sortValue['direction']) == 'desc') {
-					$sortValue['field'] = 's.reversestamp';
-					$sortValue['direction'] = 'ASC';
-				} # if
-				
 				$sortList[] = $sortValue['field'] . ' ' . $sortValue['direction'];
 			} # if
 		} # foreach
@@ -399,7 +388,6 @@ class Dao_Base_Spot implements Dao_Spot {
 			$spot['spotterid'] = substr($spot['spotterid'], 0, 31);
 			$spot['catgory'] = (int) $spot['category'];
 			$spot['stamp'] = (int) $spot['stamp'];
-			$spot['reversestamp'] = (int) ($spot['stamp'] * -1);
 
             /*
              * Make sure we only store valid utf-8
@@ -413,13 +401,13 @@ class Dao_Base_Spot implements Dao_Spot {
 
 		$this->_conn->batchInsert($spots,
 								  "INSERT INTO spots(messageid, poster, title, tag, category, subcata, 
-														subcatb, subcatc, subcatd, subcatz, stamp, reversestamp, filesize, spotterid) 
+														subcatb, subcatc, subcatd, subcatz, stamp, filesize, spotterid) 
 									VALUES",
                                   array(PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR,
                                         PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_INT,
-                                        PDO::PARAM_INT, PDO::PARAM_STR),
+                                        PDO::PARAM_STR),
 								  array('messageid', 'poster', 'title', 'tag', 'category', 'subcata', 'subcatb', 'subcatc',
-								  		'subcatd', 'subcatz', 'stamp', 'reversestamp', 'filesize', 'spotterid')
+								  		'subcatd', 'subcatz', 'stamp', 'filesize', 'spotterid')
 								  );
 
 		if (!empty($fullSpots)) {

--- a/lib/dao/Postgresql/Dao_Postgresql_Spot.php
+++ b/lib/dao/Postgresql/Dao_Postgresql_Spot.php
@@ -127,8 +127,7 @@ class Dao_Postgresql_Spot extends Dao_Base_Spot {
 	                                l.download as downloadstamp, 
 	                                l.watch as watchstamp,
 	                                l.seen AS seenstamp,
-                                    bl.idtype as idtype,
-                                    s.reversestamp as reversestamp
+                                    bl.idtype as idtype
 								    " . $extendedFieldList . " \n
 								    FROM spots AS s " . 
 								    $additionalTableList . " \n" .

--- a/lib/dao/Sqlite/Dao_Sqlite_Spot.php
+++ b/lib/dao/Sqlite/Dao_Sqlite_Spot.php
@@ -124,7 +124,6 @@ class Dao_Sqlite_Spot extends Dao_Base_Spot {
 			$spot['spotterid'] = substr($spot['spotterid'], 0, 31);
 			$spot['catgory'] = (int) $spot['category'];
 			$spot['stamp'] = (int) $spot['stamp'];
-			$spot['reversestamp'] = (int) ($spot['stamp'] * -1);
 
             /*
              * Make sure we only store valid utf-8
@@ -138,13 +137,13 @@ class Dao_Sqlite_Spot extends Dao_Base_Spot {
 
 		$this->_conn->batchInsert($spots,
 								  "INSERT INTO spots(messageid, poster, title, tag, category, subcata, 
-														subcatb, subcatc, subcatd, subcatz, stamp, reversestamp, filesize, spotterid) 
+														subcatb, subcatc, subcatd, subcatz, stamp, filesize, spotterid) 
 									VALUES",
                                   array(PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR,
-                                        PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_INT,
-                                        PDO::PARAM_STR, PDO::PARAM_STR),
+                                        PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR,
+                                        PDO::PARAM_STR),
 								  array('messageid', 'poster', 'title', 'tag', 'category', 'subcata', 'subcatb', 'subcatc',
-								  		'subcatd', 'subcatz', 'stamp', 'reversestamp', 'filesize', 'spotterid')
+								  		'subcatd', 'subcatz', 'stamp', 'filesize', 'spotterid')
 								  );
 
 		if (!empty($fullSpots)) {

--- a/lib/dbstruct/SpotStruct_abs.php
+++ b/lib/dbstruct/SpotStruct_abs.php
@@ -280,6 +280,7 @@ abstract class SpotStruct_abs {
 		$this->dropIndex("idx_nntp_2", "nntp");
 		$this->dropIndex("idx_nntp_3", "nntp");
 		$this->dropIndex("idx_spotteridblacklist_3", "spotteridblacklist");
+		$this->dropIndex("idx_spots_3", "spots");
 		
 		# Drop any non-valid FK relations
 		$this->dropForeignKey('spotsfull', 'messageid', 'spots', 'messageid', 'ON DELETE CASCADE ON UPDATE CASCADE');
@@ -352,7 +353,6 @@ abstract class SpotStruct_abs {
 		$this->validateColumn('subcatd', 'spots', 'VARCHAR(64)', NULL, false, 'ascii'); 
 		$this->validateColumn('subcatz', 'spots', 'VARCHAR(64)', NULL, false, 'ascii'); 
 		$this->validateColumn('stamp', 'spots', 'UNSIGNED INTEGER', NULL, false, '');
-		$this->validateColumn('reversestamp', 'spots', 'INTEGER', "0", false, '');
 		$this->validateColumn('filesize', 'spots', 'UNSIGNED BIGINTEGER', "0", true, '');
 		$this->validateColumn('moderated', 'spots', 'BOOLEAN', NULL, false, '');
 		$this->validateColumn('commentcount', 'spots', 'INTEGER', "0", false, '');
@@ -694,7 +694,6 @@ abstract class SpotStruct_abs {
 		# ---- Indexes on spots -----
 		$this->validateIndex("idx_spots_1", "UNIQUE", "spots", array("messageid"));
 		$this->validateIndex("idx_spots_2", "", "spots", array("stamp"));
-		$this->validateIndex("idx_spots_3", "", "spots", array("reversestamp"));
 		$this->validateIndex("idx_spots_4", "", "spots", array("category", "subcata", "subcatb", "subcatc", "subcatd", "subcatz"));
 		$this->validateIndex("idx_spots_5", "", "spots", array("spotterid"));
 		$this->validateFts("idx_fts_spots", "spots",  array(1 => "poster",
@@ -805,7 +804,8 @@ abstract class SpotStruct_abs {
 		$this->dropColumn('userid', 'spotteridblacklist');
 		$this->dropColumn('userid', 'commentsfull');
         $this->dropColumn('serialized', 'cache');
-        $this->dropColumn('content', 'cache');
+		$this->dropColumn('content', 'cache');
+		$this->dropColumn('reversestamp', 'spots');
 
         ##############################################################################################
         # Drop old tables ############################################################################


### PR DESCRIPTION
This is part of @GieltjE 's #314 to remove the reversestamp column and nothing else. Also mentioned in #294 . `upgrade-db.php` took a bit over 5 minutes to remove the index + column from MySQL 5.7 (database with all spots+comments since the beginning). SQLite won't remove the column, but it doesn't do any harm anyways. That's also the reason I didn't increase the `SPOTDB_SCHEMA_VERSION`. Users can run `upgrade-db.php` if they feel like it.