### PR TITLE
continue within switch produces warnings

### DIFF
--- a/lib/services/Format/Services_Format_ParsingLegacy.php
+++ b/lib/services/Format/Services_Format_ParsingLegacy.php
@@ -45,7 +45,7 @@ class Services_Format_ParsingLegacy {
 								$startIndex += 3;
 							} # if 
 
-							continue;
+							break;
 						} # case '=' 
 
 						case '?': {
@@ -53,7 +53,7 @@ class Services_Format_ParsingLegacy {
 								$startIndex += 2;
 							} # if
 
-							continue;
+							break;
 						} # case '?' 
 					} # switch
 


### PR DESCRIPTION
To get out of the current switch, use break, not continue. They do the same, but break doesn't produce a warning.
To break out of switch and the outer while, use continue 2.
To break out of switch, the outer while and the outer switch, use continue 3.