### PR TITLE
Update Services_Format_ParsingLegacy.php

### DIFF
--- a/lib/services/Format/Services_Format_ParsingLegacy.php
+++ b/lib/services/Format/Services_Format_ParsingLegacy.php
@@ -110,7 +110,7 @@ class Services_Format_ParsingLegacy {
 						$builder = '';
 						$num += 2;
 						$bliep = true;
-						continue;						
+						break;						
 				} # case '?' 
 			} # switch
 


### PR DESCRIPTION
Freshly installed spotweb couldn't load any spots and was throwing errors, because php expects the switch to end with a break and doesn't supress the loop with the used continue.