### PR TITLE
fix for when there are no meta headers

### DIFF
--- a/lib/services/NzbHandler/Services_NzbHandler_abs.php
+++ b/lib/services/NzbHandler/Services_NzbHandler_abs.php
@@ -230,18 +230,21 @@ abstract class Services_NzbHandler_abs
             $oneNzbFile = simplexml_load_string($nzb['nzb']);
 
             // go through all the head -> meta elements
-            foreach ($oneNzbFile->head->meta as $meta) {
-                // check for password type
-                if ($meta['type'] == 'password') {
-                    // create a meta element with the password as value
-                    $domMeta = $dom->createElement('meta', ''.$meta[0]);
-                    // create attribute: type=password
-                    $domAttribute = $dom->createAttribute('type');
-                    $domAttribute->value = 'password';
-                    // append attribute to meta-element
-                    $domMeta->appendChild($domAttribute);
-                    // append meta-element to head
-                    $domHead->appendChild($domMeta);
+            if (is_object($oneNzbFile->head->meta))
+            {
+                foreach ($oneNzbFile->head->meta as $meta) {
+                    // check for password type
+                    if ($meta['type'] == 'password') {
+                        // create a meta element with the password as value
+                        $domMeta = $dom->createElement('meta', ''.$meta[0]);
+                        // create attribute: type=password
+                        $domAttribute = $dom->createAttribute('type');
+                        $domAttribute->value = 'password';
+                        // append attribute to meta-element
+                        $domMeta->appendChild($domAttribute);
+                        // append meta-element to head
+                        $domHead->appendChild($domMeta);
+                    }
                 }
             }
         }


### PR DESCRIPTION
i noticed that i get error's when downloading nzb files, this probably happens when there are no meta fields in the NZB file.
by checking if the meta-field is actually an object, the error should be gone. (at least it is on my server)

sorry for the bad code :-(