### PR TITLE
Fix for issue: https://github.com/spotweb/spotweb/issues/566

### DIFF
--- a/lib/dao/Mysql/Dao_Mysql_Spot.php
+++ b/lib/dao/Mysql/Dao_Mysql_Spot.php
@@ -2,6 +2,35 @@
 
 class Dao_Mysql_Spot extends Dao_Base_Spot
 {
+	/*
+     * adds a list of fullspots to the database. Don't use this without having an entry in the header
+     * table as it will remove the spot from the list
+     */
+    public function addFullSpots($fullSpots)
+    {
+        SpotTiming::start(__CLASS__.'::'.__FUNCTION__);
+
+        /*
+         * Prepare the array for insertion
+         */
+        foreach ($fullSpots as &$fullSpot) {
+            $fullSpot['verified'] = (int) $fullSpot['verified'];
+            $fullSpot['user-key'] = base64_encode(serialize($fullSpot['user-key']));
+        } // foreach
+
+        $this->_conn->batchInsert(
+            $fullSpots,
+            'INSERT INTO spotsfull(messageid, verified, usersignature, userkey, xmlsignature, fullxml)
+								  	VALUES',
+            [PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR],
+            ['messageid', 'verified', 'user-signature', 'user-key', 'xml-signature', 'fullxml'], 'ON DUPLICATE KEY UPDATE messageid=messageid'
+        );
+
+        SpotTiming::stop(__CLASS__.'::'.__FUNCTION__, [$fullSpots]);
+    }
+
+    // addFullSpot
+
     /*
      * Remove a spot from the database
      */

--- a/lib/dao/Postgresql/Dao_Postgresql_Spot.php
+++ b/lib/dao/Postgresql/Dao_Postgresql_Spot.php
@@ -2,6 +2,36 @@
 
 class Dao_Postgresql_Spot extends Dao_Base_Spot
 {
+	
+	/*
+     * adds a list of fullspots to the database. Don't use this without having an entry in the header
+     * table as it will remove the spot from the list
+     */
+    public function addFullSpots($fullSpots)
+    {
+        SpotTiming::start(__CLASS__.'::'.__FUNCTION__);
+
+        /*
+         * Prepare the array for insertion
+         */
+        foreach ($fullSpots as &$fullSpot) {
+            $fullSpot['verified'] = (int) $fullSpot['verified'];
+            $fullSpot['user-key'] = base64_encode(serialize($fullSpot['user-key']));
+        } // foreach
+
+        $this->_conn->batchInsert(
+            $fullSpots,
+            'INSERT INTO spotsfull(messageid, verified, usersignature, userkey, xmlsignature, fullxml)
+								  	VALUES',
+            [PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR],
+            ['messageid', 'verified', 'user-signature', 'user-key', 'xml-signature', 'fullxml']
+        );
+
+        SpotTiming::stop(__CLASS__.'::'.__FUNCTION__, [$fullSpots]);
+    }
+
+    // addFullSpot
+
     /*
      * Remove older spots from the database
      */

--- a/lib/dao/Sqlite/Dao_Sqlite_Spot.php
+++ b/lib/dao/Sqlite/Dao_Sqlite_Spot.php
@@ -2,6 +2,36 @@
 
 class Dao_Sqlite_Spot extends Dao_Base_Spot
 {
+	
+	/*
+     * adds a list of fullspots to the database. Don't use this without having an entry in the header
+     * table as it will remove the spot from the list
+     */
+    public function addFullSpots($fullSpots)
+    {
+        SpotTiming::start(__CLASS__.'::'.__FUNCTION__);
+
+        /*
+         * Prepare the array for insertion
+         */
+        foreach ($fullSpots as &$fullSpot) {
+            $fullSpot['verified'] = (int) $fullSpot['verified'];
+            $fullSpot['user-key'] = base64_encode(serialize($fullSpot['user-key']));
+        } // foreach
+
+        $this->_conn->batchInsert(
+            $fullSpots,
+            'INSERT INTO spotsfull(messageid, verified, usersignature, userkey, xmlsignature, fullxml)
+								  	VALUES',
+            [PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR],
+            ['messageid', 'verified', 'user-signature', 'user-key', 'xml-signature', 'fullxml']
+        );
+
+        SpotTiming::stop(__CLASS__.'::'.__FUNCTION__, [$fullSpots]);
+    }
+
+    // addFullSpot
+
     /*
      * Returns the spots in the database which match the
      * restrictions of $parsedSearch


### PR DESCRIPTION
Copied `public function addFullSpots($fullSpots)` from lib/dao/Base/Dao_Base_Spot.php into :

lib/dao/Mysql/Dao_Mysql_Spot.php (function changed)
lib/dao/Postgresql/Dao_Postgresql_Spot.php (function unchanged)
lib/dao/Sqlite/Dao_Sqlite_Spot.php (function unchanged)

In lib/dao/Mysql/Dao_Mysql_Spot.php changed query from 

            'INSERT INTO spotsfull(messageid, verified, usersignature, userkey, xmlsignature, fullxml)
								  	VALUES',
            [PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR],
            ['messageid', 'verified', 'user-signature', 'user-key', 'xml-signature', 'fullxml']

Into: 

            'INSERT INTO spotsfull(messageid, verified, usersignature, userkey, xmlsignature, fullxml)
								  	VALUES',
            [PDO::PARAM_STR, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR, PDO::PARAM_STR],
            ['messageid', 'verified', 'user-signature', 'user-key', 'xml-signature', 'fullxml'], 'ON DUPLICATE KEY UPDATE messageid=messageid'

This time left lib/dao/Base/Dao_Base_Spot.php intact, removal caused the error in previous pull-request.