### PR TITLE
Fix error during setup

### DIFF
--- a/lib/dbeng/dbeng_pdo_mysql.php
+++ b/lib/dbeng/dbeng_pdo_mysql.php
@@ -44,7 +44,7 @@ class dbeng_pdo_mysql extends dbeng_pdo
 
     public function connectRoot($host, $pass, $port)
     {
-        $this->connect($host, 'root', $pass, '', $port);
+        $this->connect($host, 'root', $pass, '', $port, '');
     }
 
     public function createDb($db, $usr, $pass)


### PR DESCRIPTION
Fix this error during setup of SpotWeb using a MySQL database:
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function dbeng_pdo_mysql::connect(), 5 passed in /volume1/web/spotweb/lib/dbeng/dbeng_pdo_mysql.php on line 47 and exactly 6 expected in /volume1/web/spotweb/lib/dbeng/dbeng_pdo_mysql.php:19