### PR TITLE
Update SpotInstall.php

### DIFF
--- a/lib/SpotInstall.php
+++ b/lib/SpotInstall.php
@@ -79,6 +79,17 @@ class SpotInstall
          */
         $databaseCreated = false;
         if ($form['submit'] === 'Verify database') {
+            
+            if (($form['engine'] == 'pdo_mysql') and (empty($form['port'])))
+                {
+                    $form['port'] = '3306';
+                }
+
+            if (($form['engine'] == 'pdo_pgsql') and (empty($form['port'])))
+                {
+                    $form['port'] = '5432';
+                }
+            
             try {
                 $dbCon = dbeng_abs::getDbFactory($form['engine']);
 


### PR DESCRIPTION
If during installation by mistake the port is left empty for MySQL or PgSQL , assume the defaults MySQL port: 3306 / PgSQL port: 5432