### PR TITLE
Update Services_NzbHandler_abs.php

### DIFF
--- a/lib/services/NzbHandler/Services_NzbHandler_abs.php
+++ b/lib/services/NzbHandler/Services_NzbHandler_abs.php
@@ -276,7 +276,7 @@ abstract class Services_NzbHandler_abs
         $tmpZip = tempnam(sys_get_temp_dir(), 'SpotWebZip');
 
         $zip = new ZipArchive();
-        $res = $zip->open($tmpZip, ZipArchive::CREATE);
+        $res = $zip->open($tmpZip, ZipArchive::OVERWRITE); /* truncate as empty file is not valid */
         if ($res !== true) {
             throw new Exception('Unable to create temporary ZIP file: '.$res);
         } // if


### PR DESCRIPTION
https://github.com/spotweb/spotweb/issues/637

PHP Deprecated: ZipArchive::open(): Using empty file as ZipArchive is deprecated in /lib/services/NzbHandler/Services_NzbHandler_abs.php on line 287

Reference:

https://www.php.net/manual/en/ziparchive.open.php Example 3#

spotweb/lib/services/NzbHandler/Services_NzbHandler_abs.php

Line 279 in 81200b9
 $res = $zip->open($tmpZip, ZipArchive::CREATE); 

into

$res = $zip->open($tmpZip, ZipArchive::OVERWRITE); /* truncate as empty file is not valid */