### PR TITLE
Full table name used instead of alias

### DIFF
--- a/lib/services/Search/Services_Search_QueryParser.php
+++ b/lib/services/Search/Services_Search_QueryParser.php
@@ -628,7 +628,7 @@ class Services_Search_QueryParser
                             'tablealias'                  => 'spots',
                             'jointype'                    => 'LEFT',
                             'joincondition'               => 'spots.messageid = s.messageid', ];
-                        $tmpFilterValue = ' (spotsposted.ouruserid = '.$this->_dbEng->safe((int) $currentSession['user']['userid']).') ';
+                        $tmpFilterValue = ' (spots.ouruserid = '.$this->_dbEng->safe((int) $currentSession['user']['userid']).') ';
                         $sortFields[] = ['field' => 'spots.stamp',
                             'direction'          => 'DESC',
                             'autoadded'          => true,


### PR DESCRIPTION
Mysql crashed on myspotsposted page because full table name was used instead of reference.

Error: SpotWeb v0.68.33.34 on PHP v8.0.12 crashed 42S22: 1054: Unknown column 'spotsposted.ouruserid' in 'where clause'