### PR TITLE
Detect https for Nginx reverse proxies

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -139,8 +139,12 @@ if (!isset($_SERVER['HTTP_X_FORWARDED_URI'])) {
 }
 $ssloverride = (isset($settings['ssloverride']) ? $settings['ssloverride'] : false);
 $httpxssl = isset($_SERVER['HTTP_X_SSL']);
-if (isset($_SERVER['SERVER_PROTOCOL'])) {
-    $nwsetting = (((isset($_SERVER['HTTPS']) and $_SERVER['HTTPS'] == 'on') or ($ssloverride == true) or ($httpxssl == true)) ? 'https' : 'http').'://'.@$_SERVER['HTTP_HOST'].$loc;
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+    $nwsetting = $_SERVER['HTTP_X_FORWARDED_PROTO'].'://'.@$_SERVER['HTTP_HOST'].$loc;
+} else if (isset($_SERVER['HTTP_X_FORWARDED_SSL'])) {
+    $nwsetting = ($_SERVER['HTTP_X_FORWARDED_SSL'] == 'on' ? 'https' : 'http').'://'.@$_SERVER['HTTP_HOST'].$loc;
+} else if (isset($_SERVER['SERVER_PROTOCOL'])) {
+    $nwsetting = (((isset($_SERVER['HTTPS']) and $_SERVER['HTTPS'] == 'on') or ($ssloverride == true) or ($httpxssl == true)) ? 'https' : 'http') . '://' . @$_SERVER['HTTP_HOST'] . $loc;
 } else {
     $nwsetting = 'http://mijnuniekeservernaam/spotweb/';
 } // if

--- a/settings.php
+++ b/settings.php
@@ -141,10 +141,10 @@ $ssloverride = (isset($settings['ssloverride']) ? $settings['ssloverride'] : fal
 $httpxssl = isset($_SERVER['HTTP_X_SSL']);
 if (isset($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
     $nwsetting = $_SERVER['HTTP_X_FORWARDED_PROTO'].'://'.@$_SERVER['HTTP_HOST'].$loc;
-} else if (isset($_SERVER['HTTP_X_FORWARDED_SSL'])) {
+} elseif (isset($_SERVER['HTTP_X_FORWARDED_SSL'])) {
     $nwsetting = ($_SERVER['HTTP_X_FORWARDED_SSL'] == 'on' ? 'https' : 'http').'://'.@$_SERVER['HTTP_HOST'].$loc;
-} else if (isset($_SERVER['SERVER_PROTOCOL'])) {
-    $nwsetting = (((isset($_SERVER['HTTPS']) and $_SERVER['HTTPS'] == 'on') or ($ssloverride == true) or ($httpxssl == true)) ? 'https' : 'http') . '://' . @$_SERVER['HTTP_HOST'] . $loc;
+} elseif (isset($_SERVER['SERVER_PROTOCOL'])) {
+    $nwsetting = (((isset($_SERVER['HTTPS']) and $_SERVER['HTTPS'] == 'on') or ($ssloverride == true) or ($httpxssl == true)) ? 'https' : 'http').'://'.@$_SERVER['HTTP_HOST'].$loc;
 } else {
     $nwsetting = 'http://mijnuniekeservernaam/spotweb/';
 } // if


### PR DESCRIPTION
I wanted to use Spotweb with the [jgeusebroek/spotweb](https://github.com/jgeusebroek/docker-spotweb) image and was unpleasantly surprised the site did not behave well with my reverse proxy and requests were failing because of [mixed content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content).
Using a Nginx web server to reverse proxy and provide SSL to the public domain.

The HTTPheader `X_FORWARDED_PROTO` is a very common header to let other servers/software behind the proxy know which protocol was used to access the site.
Honestly I was surprised this was not in the source for a code base this much used and well established.

The if statements were placed above the original statement because the `SERVER_PROTOCOL` header is always set by Apache. 

One thing I don't understand is why `SERVER_PROTOCOL` is checked anyways because it contains the HTTP version. Was this a typo?
The following was generated from `var_dump($_SERVER)` demonstrating the contents of `SERVER_PROTOCOL`.
```
["SERVER_PROTOCOL"]=> string(8) "HTTP/1.1"
```

I also added the `X_FORWARDED_SSL` header as a fallback as this header is often set (in conjunction with `X_FORWARDED_PROTO`) when Nginx acts as a reverse proxy. 

This should also fix, rather than close, #45