### PR TITLE
Added missing $smtp argument to sendMessage() signature

### DIFF
--- a/lib/notifications/Notifications_Growl.php
+++ b/lib/notifications/Notifications_Growl.php
@@ -24,7 +24,7 @@ class Notifications_Growl extends Notifications_abs
 
     // register
 
-    public function sendMessage($type, $title, $body, $sourceUrl)
+    public function sendMessage($type, $title, $body, $sourceUrl, $smtp)
     {
         $this->growlObj->notify($this->_connection, $type, $title, $body);
     }

--- a/lib/notifications/Notifications_Prowl.php
+++ b/lib/notifications/Notifications_Prowl.php
@@ -24,7 +24,7 @@ class Notifications_Prowl extends Notifications_abs
 
     // register
 
-    public function sendMessage($type, $title, $body, $sourceUrl)
+    public function sendMessage($type, $title, $body, $sourceUrl, $smtp)
     {
         if (version_compare(PHP_VERSION, '5.3.0') >= 0) {
             $oMsg = new \Prowl\Message();

--- a/lib/notifications/Notifications_Twitter.php
+++ b/lib/notifications/Notifications_Twitter.php
@@ -52,7 +52,7 @@ class Notifications_Twitter extends Notifications_abs
 
     // verifyPIN
 
-    public function sendMessage($type, $title, $body, $sourceUrl)
+    public function sendMessage($type, $title, $body, $sourceUrl, $smtp)
     {
         $this->twitterObj = new TwitterOAuth($this->dataArray['consumer_key'], $this->dataArray['consumer_secret'], $this->dataArray['access_token'], $this->dataArray['access_token_secret']);
 


### PR DESCRIPTION
Fixes compatibility with `Notifications_abs::sendMessage()`