### PR TITLE
fix: attachInfiniteScroll not work on widescreen monitors

### DIFF
--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -169,10 +169,10 @@ function attachInfiniteScroll() {
 	var pagenr = $('#nextPage').val();
 	$(window).scroll(function() {
 		const {
-            scrollTop,
-            scrollHeight,
-            clientHeight
-        } = document.documentElement;
+			scrollTop,
+			scrollHeight,
+			clientHeight
+		} = document.documentElement;
 		const endOfPage = scrollTop + clientHeight >= scrollHeight - 5;
 
 		var url = '?direction=next&data[spotsonly]=1&pagenr='+pagenr+$('#getURL').val()+' #spots';

--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -168,9 +168,16 @@ function attachInfiniteScroll() {
 // console.time("2nd-ready");
 	var pagenr = $('#nextPage').val();
 	$(window).scroll(function() {
+		const {
+            scrollTop,
+            scrollHeight,
+            clientHeight
+        } = document.documentElement;
+		const endOfPage = scrollTop + clientHeight >= scrollHeight - 5;
+
 		var url = '?direction=next&data[spotsonly]=1&pagenr='+pagenr+$('#getURL').val()+' #spots';
 
-		if($(document).scrollTop() >= $(document).height() - $(window).height() && $(document).height() >= $(window).height() && pagenr > 0 && $("#overlay").is(':hidden')) {
+		if(endOfPage && $(document).height() >= $(window).height() && pagenr > 0 && $("#overlay").is(':hidden')) {
 			if(!($("div.spots").hasClass("full"))) {
 				var scrollLocation = $("div.container").scrollTop();
 				$("#overlay").show().addClass('loading');


### PR DESCRIPTION
Hey @mesa57!

I found a bug on infinite scroll, not sure why happens only on my widescreen monitor(when I resize the height of the browser it worked again)

I just checked this [tutorial](https://www.javascripttutorial.net/javascript-dom/javascript-infinite-scroll/) and applied a patch.

I tested it in various sizes, working without issues.

Regards :)