### PR TITLE
Remove query parameters from spotweburl

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -133,10 +133,10 @@ if ((!is_readable($settings['openssl_cnf_path'])) && extension_loaded('openssl')
  * use HTTPS in case of HTTPS in server vars or ssloveride in ownsettings or HTTP_X_SSL in server vars
  * For use of an nginx reverse proxy x_forwarded_uri $request_uri can be added if the location differs from the default location
  */
-if (!isset($_SERVER['HTTP_X_FORWARDED_URI'])) {
+if (empty($_SERVER['HTTP_X_FORWARDED_URI'])) {
     $loc = (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']).'/' : '/');
 } else {
-    $loc = ($_SERVER['HTTP_X_FORWARDED_URI'] != '/' && $_SERVER['HTTP_X_FORWARDED_URI'] != '\\' ? strtok($_SERVER['HTTP_X_FORWARDED_URI'], '?').'/' : '/');
+    $loc = ($_SERVER['HTTP_X_FORWARDED_URI'] != '/' && $_SERVER['HTTP_X_FORWARDED_URI'] != '\\' ? strtok($_SERVER['HTTP_X_FORWARDED_URI'], '?') : '/');
 }
 $ssloverride = (isset($settings['ssloverride']) ? $settings['ssloverride'] : false);
 $httpxssl = isset($_SERVER['HTTP_X_SSL']);

--- a/settings.php
+++ b/settings.php
@@ -136,7 +136,7 @@ if ((!is_readable($settings['openssl_cnf_path'])) && extension_loaded('openssl')
 if (!isset($_SERVER['HTTP_X_FORWARDED_URI'])) {
     $loc = (dirname($_SERVER['PHP_SELF']) != '/' && dirname($_SERVER['PHP_SELF']) != '\\' ? dirname($_SERVER['PHP_SELF']).'/' : '/');
 } else {
-    $loc = ($_SERVER['HTTP_X_FORWARDED_URI'] != '/' && $_SERVER['HTTP_X_FORWARDED_URI'] != '\\' ? $_SERVER['HTTP_X_FORWARDED_URI'].'/' : '/');
+    $loc = ($_SERVER['HTTP_X_FORWARDED_URI'] != '/' && $_SERVER['HTTP_X_FORWARDED_URI'] != '\\' ? strtok($_SERVER['HTTP_X_FORWARDED_URI'], '?').'/' : '/');
 }
 $ssloverride = (isset($settings['ssloverride']) ? $settings['ssloverride'] : false);
 $httpxssl = isset($_SERVER['HTTP_X_SSL']);


### PR DESCRIPTION
In case Spotweb runs behind a reverse proxy we use `$_SERVER['HTTP_X_FORWARDED_URI']` to determine the spotweburl setting. It should not contain any query parameters, so we remove it.

Without this fix, buttons like the "Add to SABnzbd queue" button (green arrow down) will fail with a JavaScript alert window showing some HTML.