### PR TITLE
Update templates and mobile filters / bugfix

### DIFF
--- a/templates/mobile/filters.inc.php
+++ b/templates/mobile/filters.inc.php
@@ -99,7 +99,7 @@ $sortType = $currentSession['user']['prefs']['defaultsortfield'];
                     }
 
                     echo '<li>';
-                    echo '<a href="'.$imageFilter.'#spots" rel="external"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
+                    echo '<a href="'.$imageFilter.'#spots" rel="external" class="js-mobile-filter"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
                     processImage($tplHelper, $count_newspots, $filter['children'], $defaultSortField);
                     echo '</li>';
                 }
@@ -160,7 +160,7 @@ $sortType = $currentSession['user']['prefs']['defaultsortfield'];
                     }
 
                     echo '<li>';
-                    echo '<a href="'.$soundsFilter.'#spots" rel="external"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
+                    echo '<a href="'.$soundsFilter.'#spots" rel="external" class="js-mobile-filter"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
                     processSounds($tplHelper, $count_newspots, $filter['children'], $defaultSortField);
                     echo '</li>';
                 }
@@ -221,7 +221,7 @@ $sortType = $currentSession['user']['prefs']['defaultsortfield'];
                     }
 
                     echo '<li>';
-                    echo '<a href="'.$gamesFilter.'#spots" rel="external"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
+                    echo '<a href="'.$gamesFilter.'#spots" rel="external" class="js-mobile-filter"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
                     processGames($tplHelper, $count_newspots, $filter['children'], $defaultSortField);
                     echo '</li>';
                 }
@@ -282,7 +282,7 @@ $sortType = $currentSession['user']['prefs']['defaultsortfield'];
                     }
 
                     echo '<li>';
-                    echo '<a href="'.$appsFilter.'#spots" rel="external"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
+                    echo '<a href="'.$appsFilter.'#spots" rel="external" class="js-mobile-filter"><img src="templates/mobile/icons/'.$filter['icon'].'.png" class="ui-li-icon"/>'.$filter['title'].'</a>';
                     processApps($tplHelper, $count_newspots, $filter['children'], $defaultSortField);
                     echo '</li>';
                 }

--- a/templates/mobile/header.inc.php
+++ b/templates/mobile/header.inc.php
@@ -14,6 +14,7 @@
 		<script src='https://code.jquery.com/jquery-1.8.2.js' type='text/javascript'></script>
 		<script src='js/jquery.mobile-1.4.5/jquery.mobile-1.4.5.js' type='text/javascript'></script>
         <script src='templates/mobile/includes/js/spotdialogs.js' type='text/javascript'></script>
+        <script src='templates/mobile/includes/js/mobile-filters.js' type='text/javascript'></script>
 		<style>
 		    th{text-align:left;}
 		</style>

--- a/templates/mobile/includes/js/mobile-filters.js
+++ b/templates/mobile/includes/js/mobile-filters.js
@@ -1,0 +1,138 @@
+/* Persist mobile filter selection and apply it to the Search form. */
+(function () {
+    "use strict";
+
+    var STORAGE_KEY = "spotweb.mobile.filters";
+
+    function parseQuery(queryString) {
+        var params = {};
+        if (!queryString) {
+            return params;
+        }
+        queryString.split("&").forEach(function (part) {
+            if (!part) {
+                return;
+            }
+            var pieces = part.split("=");
+            var rawKey = pieces[0] || "";
+            var rawValue = pieces.length > 1 ? pieces.slice(1).join("=") : "";
+            var key = decodeURIComponent(rawKey.replace(/\+/g, " "));
+            var value = decodeURIComponent(rawValue.replace(/\+/g, " "));
+
+            if (key === "search[value][]") {
+                if (!params[key]) {
+                    params[key] = [];
+                }
+                params[key].push(value);
+            } else {
+                params[key] = value;
+            }
+        });
+        return params;
+    }
+
+    function extractSearchParamsFromUrl(url) {
+        if (!url) {
+            return {};
+        }
+        var queryIndex = url.indexOf("?");
+        if (queryIndex === -1) {
+            return {};
+        }
+        var query = url.slice(queryIndex + 1);
+        var hashIndex = query.indexOf("#");
+        if (hashIndex !== -1) {
+            query = query.slice(0, hashIndex);
+        }
+        return parseQuery(query);
+    }
+
+    function hasFilterParams(params) {
+        return Boolean(params["search[tree]"] || params["search[value][]"] || params["search[value]"]);
+    }
+
+    function storeFilterParams(params) {
+        if (!hasFilterParams(params)) {
+            return;
+        }
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(params));
+        } catch (e) {
+            /* ignore storage errors */
+        }
+    }
+
+    function loadStoredFilters() {
+        try {
+            var raw = localStorage.getItem(STORAGE_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function clearExistingFilterInputs(form) {
+        var existing = form.querySelectorAll("input[data-mobile-filter='1']");
+        for (var i = 0; i < existing.length; i++) {
+            existing[i].parentNode.removeChild(existing[i]);
+        }
+    }
+
+    function addHiddenInput(form, name, value) {
+        var input = document.createElement("input");
+        input.type = "hidden";
+        input.name = name;
+        input.value = value;
+        input.setAttribute("data-mobile-filter", "1");
+        form.appendChild(input);
+    }
+
+    function applyFiltersToSearchForm() {
+        var form = document.getElementById("filterform");
+        if (!form) {
+            return;
+        }
+
+        clearExistingFilterInputs(form);
+
+        var stored = loadStoredFilters();
+        if (!stored || !hasFilterParams(stored)) {
+            return;
+        }
+
+        if (stored["search[tree]"]) {
+            addHiddenInput(form, "search[tree]", stored["search[tree]"]);
+        }
+
+        if (stored["search[value][]"]) {
+            var values = stored["search[value][]"];
+            if (!Array.isArray(values)) {
+                values = [values];
+            }
+            for (var i = 0; i < values.length; i++) {
+                addHiddenInput(form, "search[value][]", values[i]);
+            }
+        } else if (stored["search[value]"]) {
+            addHiddenInput(form, "search[value]", stored["search[value]"]);
+        }
+    }
+
+    function captureFiltersFromLocation() {
+        var params = extractSearchParamsFromUrl(window.location.href);
+        storeFilterParams(params);
+    }
+
+    $(document).on("click", "a.js-mobile-filter", function () {
+        var params = extractSearchParamsFromUrl(this.href);
+        storeFilterParams(params);
+    });
+
+    $(document).on("pageshow", "#search", function () {
+        applyFiltersToSearchForm();
+    });
+
+    $(document).ready(function () {
+        captureFiltersFromLocation();
+        applyFiltersToSearchForm();
+    });
+}());

--- a/templates/modern/css/cards.css
+++ b/templates/modern/css/cards.css
@@ -1,18 +1,18 @@
 /* Cards view for modern theme */
 
-.cardsGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 14px; }
+.cardsGrid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 8px; }
 
 .spotCard {
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 10px;
-  padding: 10px;
+  padding: 6px;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
-.spotCard .thumb img { width: 100%; height: 180px; object-fit: cover; border-radius: 8px; display: block; }
+.spotCard .thumb img { width: 100%; height: 90px; object-fit: cover; border-radius: 8px; display: block; }
 
 .spotCard .topRow { display: flex; align-items: center; gap: 8px; }
 .spotCard .badge { font-weight: bold; font-size: 11px; padding: 2px 6px; border-radius: 6px; color: #fff; }
@@ -21,18 +21,25 @@
 .spotCard.spotcat2 .badge { background: #22c55e; }
 .spotCard.spotcat3 .badge { background: #ef4444; }
 
-.spotCard .title a { color: var(--color-text) !important; text-decoration: none; font-weight: 700; letter-spacing: .1px; }
+.spotCard .title a {
+  color: var(--color-text) !important;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0;
+  font-size: 12.5px;
+  line-height: 1.25;
+}
 .spotCard .title a:hover { text-decoration: underline; }
 
-.spotCard .meta { display: flex; flex-wrap: wrap; gap: 10px; color: var(--color-muted); font-size: 12.5px; }
+.spotCard .meta { display: flex; flex-wrap: wrap; gap: 6px; color: var(--color-muted); font-size: 11.5px; }
 .spotCard .meta a { color: var(--color-text) !important; text-decoration: none; }
 .spotCard .meta span { display: inline-flex; align-items: center; gap: 4px; }
 
-.spotCard .actions { display: flex; align-items: center; gap: 8px; margin-top: 2px; }
+.spotCard .actions { display: flex; align-items: center; gap: 5px; margin-top: 2px; }
 .spotCard .actions a.nzb { background: var(--color-accent); color: #fff; border-radius: 6px; padding: 4px 8px; text-decoration: none; font-weight: 600; }
 .spotCard .actions a.nzb.downloaded { opacity: 0.75; }
 
-.spotCard .footerRow { display: flex; align-items: center; justify-content: space-between; margin-top: 4px; }
+.spotCard .footerRow { display: flex; align-items: center; justify-content: space-between; margin-top: 2px; }
 .spotCard .comments { font-weight: 700; color: var(--color-accent) !important; text-decoration: none; }
 .spotCard .comments:hover { text-decoration: underline; }
 .spotCard .watch { display: inline-flex; align-items: center; gap: 6px; }
@@ -74,7 +81,7 @@ html[data-theme="dark"] .spotCard:hover { background: var(--color-surface-2); }
 /* Density adjustments */
 html[data-density="compact"] .cardsGrid { gap: 8px; }
 html[data-density="compact"] .spotCard { padding: 8px; gap: 6px; }
-html[data-density="compact"] .spotCard .thumb img { height: 150px; }
-html[data-density="compact"] .spotCard .meta { font-size: 11px; gap: 8px; }
+html[data-density="compact"] .spotCard .thumb img { height: 80px; }
+html[data-density="compact"] .spotCard .meta { font-size: 11px; gap: 6px; }
 html[data-density="compact"] .spotCard .actions a.nzb { padding: 3px 6px; font-size: 12px; }
 

--- a/templates/modern/css/filters.css
+++ b/templates/modern/css/filters.css
@@ -9,9 +9,9 @@ div.filter {
   --filter-backdrop: rgba(6, 9, 15, 0.78);
   background: var(--filter-backdrop);
   backdrop-filter: blur(12px);
-  border-radius: 14px;
-  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.35);
-  padding: 10px 12px;
+  border-radius: 10px;
+  box-shadow: 0 14px 28px rgba(0, 0, 0, 0.26);
+  padding: 8px 8px;
 }
 
 html[data-theme="light"] div.filter {
@@ -39,21 +39,21 @@ div.filter ul.filterlist li a.filter {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 6px;
-  padding: 3px 32px 3px 13px;
-  border-radius: 10px;
+  gap: 5px;
+  padding: 2px 28px 2px 10px;
+  border-radius: 8px;
   position: relative;
   overflow: hidden;
   background: var(--filter-card-bg) !important;
   border: 1px solid var(--filter-card-border) !important;
   color: var(--filter-card-text) !important;
   text-decoration: none !important;
-  font-size: 0.82rem;
+  font-size: 0.75rem;
   letter-spacing: 0.006em;
-  width: 200px;
+  width: 180px;
   box-sizing: border-box;
   box-shadow: inset 4px 0 0 var(--filter-accent, rgba(148, 163, 184, 0.35)),
-              0 12px 26px var(--filter-accent-soft, rgba(15, 23, 42, 0.08));
+              0 8px 18px var(--filter-accent-soft, rgba(15, 23, 42, 0.08));
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
@@ -81,7 +81,7 @@ div.filter ul.filterlist li a.filter::after {
 
 div.filter ul.filterlist li a.filter:hover,
 div.filter ul.filterlist li a.filter:focus-visible {
-  transform: translateX(2px);
+  transform: translateX(1px);
   border-color: var(--filter-accent, rgba(148, 163, 184, 0.6)) !important;
 }
 
@@ -92,7 +92,7 @@ div.filter ul.filterlist li a.filter.selected::after {
 
 div.filter ul.filterlist li a.filter.selected {
   box-shadow: inset 4px 0 0 var(--filter-accent, rgba(148, 163, 184, 0.45)),
-              0 12px 30px var(--filter-accent-soft, rgba(15, 23, 42, 0.12));
+              0 10px 22px var(--filter-accent-soft, rgba(15, 23, 42, 0.12));
 }
 
 div.filter ul.filterlist li a.filter .newspots {
@@ -101,7 +101,7 @@ div.filter ul.filterlist li a.filter .newspots {
   border-radius: 999px;
   padding: 0 6px;
   font-weight: 500;
-  font-size: 0.8rem;
+  font-size: 0.72rem;
   margin-left: 8px;
   order: 98;
 }
@@ -122,7 +122,7 @@ div.filter ul.filterlist li span.toggle {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
 }
 
@@ -133,8 +133,8 @@ div#filter h4 {
   border: 1px solid var(--filter-card-border) !important;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  font-size: 0.75rem;
-  margin-bottom: 10px;
+  font-size: 0.7rem;
+  margin-bottom: 8px;
 }
 
 div#filter ul li {
@@ -244,37 +244,37 @@ div.filter ul.subfilterlist li[class*="spotcat5"] {
 }
 
 div.filter ul.subfilterlist {
-  margin: 8px 0 0;
-  padding-left: 12px;
+  margin: 6px 0 0;
+  padding-left: 10px;
   border-left: 2px solid var(--filter-accent, rgba(148, 163, 184, 0.4));
   list-style: none;
 }
 
 div.filter ul.subfilterlist li {
-  margin: 4px 0;
+  margin: 3px 0;
 }
 
 div.filter ul.subfilterlist li a {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 6px;
-  padding: 5px 12px 5px 18px;
-  border-radius: 10px;
+  gap: 5px;
+  padding: 4px 10px 4px 14px;
+  border-radius: 8px;
   background: var(--filter-card-bg) !important;
   border: 1px solid var(--filter-card-border) !important;
   color: var(--filter-card-text) !important;
   text-decoration: none !important;
-  font-size: 0.85rem;
+  font-size: 0.78rem;
   position: relative;
   box-shadow: inset 3px 0 0 var(--filter-accent, rgba(148, 163, 184, 0.4)),
-              0 6px 14px var(--filter-accent-soft, rgba(15, 23, 42, 0.07));
+              0 4px 10px var(--filter-accent-soft, rgba(15, 23, 42, 0.07));
   transition: transform 0.2s ease, border-color 0.2s ease;
 }
 
 div.filter ul.subfilterlist li a:hover,
 div.filter ul.subfilterlist li a:focus-visible {
-  transform: translateX(2px);
+  transform: translateX(1px);
   border-color: var(--filter-accent, rgba(148, 163, 184, 0.5)) !important;
 }
 
@@ -508,5 +508,112 @@ html[data-theme="dark"] div.sidebarPanel.advancedSearch a.greyButton.addFilter {
   border-color: var(--color-accent) !important;
 }
 
+/* We1rdo-like filters (match classic layout) */
+div#filter,
+div.filter {
+  background: none !important;
+  backdrop-filter: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+}
 
+div#filter ul,
+div.filter ul {
+  margin: 0 0 5px !important;
+  padding: 0 0 0 5px !important;
+}
+
+div#filter ul ul,
+div.filter ul ul {
+  margin: 0 0 0 10px !important;
+  padding: 0 !important;
+}
+
+div#filter li,
+div.filter li {
+  list-style: none !important;
+  margin: 0 0 5px 0 !important;
+}
+
+div#filter li li,
+div.filter li li {
+  margin: 2px 0 0 !important;
+}
+
+div#filter ul.filterlist li a.filter,
+div#filter ul.subfilterlist li a,
+div#filter ul.filterlist.quicklinks li a.filter,
+div.filter ul.filterlist li a.filter,
+div.filter ul.subfilterlist li a,
+div.filter ul.filterlist.quicklinks li a.filter {
+  display: block !important;
+  width: 100% !important;
+  background-color: #ececec !important;
+  line-height: 20px !important;
+  border-radius: 4px !important;
+  text-decoration: none !important;
+  color: #000 !important;
+  font-weight: bold !important;
+  box-shadow: none !important;
+  border: 1px solid transparent !important;
+  padding: 0 6px !important;
+  font-size: 12px !important;
+  letter-spacing: 0 !important;
+  transform: none !important;
+}
+
+div#filter > ul > li.spotcat0 a,
+div.filter > ul > li.spotcat0 a { background-color: #daecff !important; }
+div#filter > ul > li.spotcat1 a,
+div.filter > ul > li.spotcat1 a { background-color: #fffad3 !important; }
+div#filter > ul > li.spotcat2 a,
+div.filter > ul > li.spotcat2 a { background-color: #cbffcb !important; }
+div#filter > ul > li.spotcat3 a,
+div.filter > ul > li.spotcat3 a { background-color: #fedede !important; }
+
+div#filter a span.newspots,
+div.filter a span.newspots {
+  color: #333 !important;
+  margin: 0 3px 0 5px !important;
+  padding: 0 3px !important;
+  border-radius: 2px !important;
+  background: transparent !important;
+}
+
+div#filter li a.selected span.newspots,
+div.filter li a.selected span.newspots {
+  background-color: #222 !important;
+  color: #fff !important;
+}
+
+div#filter li span.toggle,
+div.filter li span.toggle {
+  display: block !important;
+  float: right !important;
+  width: 15px !important;
+  height: 14px !important;
+  margin: 2px !important;
+  border-radius: 4px !important;
+  background: url(../../we1rdo/img/sprite.png) no-repeat -77px -98px !important;
+  border: none !important;
+}
+
+div#filter li span.inclusive,
+div.filter li span.inclusive {
+  display: block !important;
+  float: right !important;
+  width: 15px !important;
+  line-height: 14px !important;
+  margin: 2px !important;
+}
+
+div#filter li.spotcat0 span.toggle,
+div.filter li.spotcat0 span.toggle { background-color: #62aefd !important; border: 1px solid #006cab !important; color: #006cab !important; }
+div#filter li.spotcat1 span.toggle,
+div.filter li.spotcat1 span.toggle { background-color: #f2d87c !important; border: 1px solid #cd9f00 !important; color: #cd9f00 !important; }
+div#filter li.spotcat2 span.toggle,
+div.filter li.spotcat2 span.toggle { background-color: #84f484 !important; border: 1px solid #00ab00 !important; color: #00ab00 !important; }
+div#filter li.spotcat3 span.toggle,
+div.filter li.spotcat3 span.toggle { background-color: #f99797 !important; border: 1px solid #ab1c00 !important; color: #ab1c00 !important; }
 

--- a/templates/modern/css/layout.css
+++ b/templates/modern/css/layout.css
@@ -1,8 +1,8 @@
 /* Modern layout and spacing */
 
 :root {
-  --sw-sidebar-w: 234px;
-  --sw-gap: 14px;
+  --sw-sidebar-w: 210px;
+  --sw-gap: 10px;
   --sw-toolbar-offset: 42px;
   --sw-header-offset: var(--sw-toolbar-offset);
   --sw-strip-gradient: linear-gradient(180deg, #5e626a 0%, #3d4046 100%);
@@ -82,7 +82,6 @@ table.spots tr.head {
   border-bottom: 1px solid var(--sw-strip-border);
 }
 
-table.spots tr td { padding: 4px 6px; }
 
 body.fixed #filter {
   position: sticky;

--- a/templates/modern/css/table.css
+++ b/templates/modern/css/table.css
@@ -1,8 +1,31 @@
 ﻿/* Modern table tweaks: thumbnails + readability */
 
-table.spots { width: 100% !important; }
-table.spots tr.head th { background: var(--color-surface-2) !important; color: var(--color-text) !important; text-shadow: none !important; }
-table.spots td { background: transparent; color: var(--color-text) !important; }
+table.spots { width: 100% !important; border-spacing: 0 0; }
+table.spots tr { height: 20px; }
+table.spots tr.head th {
+  background: var(--color-surface-2) !important;
+  color: var(--color-text) !important;
+  text-shadow: none !important;
+  height: 20px;
+  line-height: 20px;
+  padding: 0 0 0 5px;
+}
+table.spots td {
+  background: transparent;
+  color: var(--color-text) !important;
+  vertical-align: middle;
+}
+table.spots td a,
+table.spots td span,
+table.spots td label {
+  display: block;
+  height: 20px;
+  line-height: 20px;
+}
+table.spots td a {
+  overflow: hidden;
+  white-space: nowrap;
+}
 table.spots tr:hover td { background: var(--color-surface) !important; }
 
 /* Ensure links are readable in dark/light */

--- a/templates/modern/includes/header.inc.php
+++ b/templates/modern/includes/header.inc.php
@@ -52,6 +52,7 @@
 		<!-- Modern JS (loaded separately to avoid statics concatenation issues) -->
 		<script src="templates/modern/js/theme-toggle.js" type="text/javascript" defer></script>
 		<script src="templates/modern/js/back-fix.js" type="text/javascript" defer></script>
+		<script src="templates/modern/js/open-spot-fix.js" type="text/javascript" defer></script>
 		<script src="templates/modern/js/sticky-offset.js" type="text/javascript" defer></script>
 		<script src="templates/modern/js/infinite.js" type="text/javascript" defer></script>
 		<script src="templates/modern/js/table-enhance.js" type="text/javascript" defer></script>

--- a/templates/modern/js/open-spot-fix.js
+++ b/templates/modern/js/open-spot-fix.js
@@ -1,0 +1,52 @@
+(function () {
+  function setup() {
+    var originalOpenSpot = window.openSpot;
+    if (!originalOpenSpot || originalOpenSpot._modernWrapped) {
+      return;
+    }
+
+    function scrollToComments() {
+      var target = document.getElementById('comments');
+      if (!target) {
+        return false;
+      }
+      try {
+        target.scrollIntoView({ block: 'start', behavior: 'auto' });
+      } catch (e) {
+        target.scrollIntoView();
+      }
+      return true;
+    }
+
+    function openSpotWrapped(id, url) {
+      var shouldScrollToComments = false;
+      if (typeof url === 'string' && url.indexOf('#comments') !== -1) {
+        shouldScrollToComments = true;
+        url = url.split('#')[0];
+      }
+
+      var result = originalOpenSpot(id, url);
+
+      if (shouldScrollToComments) {
+        var tries = 0;
+        var timer = setInterval(function () {
+          tries += 1;
+          if (scrollToComments() || tries > 20) {
+            clearInterval(timer);
+          }
+        }, 200);
+      }
+
+      return result;
+    }
+
+    openSpotWrapped._modernWrapped = true;
+    window.openSpot = openSpotWrapped;
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', setup);
+  } else {
+    setup();
+  }
+})();

--- a/templates/modern/js/theme-toggle.js
+++ b/templates/modern/js/theme-toggle.js
@@ -31,10 +31,9 @@
       toolbar.appendChild(themeWrap);
     }
 
-    // View + Density controls
+    // View controls
     if (toolbar && !document.getElementById('viewCurrent')) {
       var viewPref = localStorage.getItem('spotweb_view') || 'cards';
-      var densityPref = localStorage.getItem('spotweb_density') || 'cozy';
 
       var viewWrap = document.createElement('div');
       viewWrap.className = 'toolbarButton theme dropdown right';
@@ -42,16 +41,8 @@
                           "<ul>" +
                           "<li><a href=\"#\" id=\"viewCards\">Cards</a></li>" +
                           "<li><a href=\"#\" id=\"viewTable\">Table</a></li>" +
-                          "<li class=\"sep\"></li>" +
-                          "<li><a href=\"#\" id=\"densityCozy\">Density: Cozy</a></li>" +
-                          "<li><a href=\"#\" id=\"densityCompact\">Density: Compact</a></li>" +
                           "</ul></li></ul>";
       toolbar.appendChild(viewWrap);
-
-      var updateDensity = function(mode){
-        try { localStorage.setItem('spotweb_density', mode); } catch(e){}
-        document.documentElement.setAttribute('data-density', mode);
-      };
 
       function setViewCookie(v){ try { document.cookie = 'spotweb_view=' + v + '; path=/; max-age=' + (60*60*24*365); } catch(e){} }
       document.getElementById('viewCards').onclick = function(){
@@ -70,11 +61,6 @@
         location.href = u.toString();
         return false;
       };
-      document.getElementById('densityCozy').onclick = function(){ updateDensity('cozy'); return false; };
-      document.getElementById('densityCompact').onclick = function(){ updateDensity('compact'); return false; };
-
-      // Apply saved density on load
-      document.documentElement.setAttribute('data-density', densityPref);
 
       // Sync cookie from storage if missing
       try {

--- a/templates/we1rdo/css/style.css
+++ b/templates/we1rdo/css/style.css
@@ -201,6 +201,10 @@ a.viewState h4 span.down {background:#333 url(../img/sprite.png) no-repeat -17px
 /* QUICKLINKS */
 div.filter ul.quicklinks li {margin:0 0 2px 0;}
 div.filter ul.quicklinks li a {}
+/* Ensure quicklinks stay stacked vertically */
+div.filter ul.filterlist.quicklinks {display:block;}
+div.filter ul.filterlist.quicklinks li {display:block !important; float:none !important; width:100% !important;}
+div.filter ul.filterlist.quicklinks li a {display:block !important; float:none !important; width:100% !important;}
 
 /* FILTERS */
 div.filter ul {margin:0 0 5px; padding:0 0 0 5px;}
@@ -339,7 +343,7 @@ div.details table.spotheader th.sabnzbd a.sabnzbd-button.failure,
 table.spots tr td a.sabnzbd-button.failure {background-position:0px -182px;}
 
 div.details table.spotheader th.spamreport a.spamreport-button,
-table.spots tr td a.spamreport-button {display:block; width:22px; height:18px; cursor:pointer; margin:0 0 1px 0; background:url(../img/sprite.png) no-repeat -54px -129px;}
+table.spots tr td a.spamreport-button {display:block; width:22px; height:18px; cursor:pointer; margin:0 0 1px 0; background:url(../img/sprite.png) no-repeat -55px -129px;}
 div.details table.spotheader th.spamreport a.spamreport-button.loading,
 table.spots tr td a.spamreport-button.loading {background:url(../img/loading.gif) no-repeat center center; margin:0 0 1px 0;}
 div.details table.spotheader th.spamreport a.spamreport-button.success,

--- a/templates/we1rdo/includes/filters.inc.php
+++ b/templates/we1rdo/includes/filters.inc.php
@@ -284,18 +284,19 @@
 <?php foreach ($quicklinks as $quicklink) {
           if ($tplHelper->allowed($quicklink[4][0], $quicklink[4][1])) {
               if (empty($quicklink[5]) || $currentSession['user']['prefs'][$quicklink[5]]) {
-                  $newCount = ($count_newspots && stripos($quicklink[2], 'New:0')) ? $tplHelper->getNewCountForFilter($quicklink[2]) : ''; ?>
-					<li> <a class="filter <?php echo ' '.$quicklink[3];
-                  if (parse_url($tplHelper->makeSelfUrl('full'), PHP_URL_QUERY) == parse_url($tplHelper->makeBaseUrl('full').$quicklink[2], PHP_URL_QUERY)) {
+                  $newCount = ($count_newspots && stripos($quicklink[2], 'New:0')) ? $tplHelper->getNewCountForFilter($quicklink[2]) : '';
+                  $isSelected = (parse_url($tplHelper->makeSelfUrl('full'), PHP_URL_QUERY) == parse_url($tplHelper->makeBaseUrl('full').$quicklink[2], PHP_URL_QUERY));
+?>
+					<li>
+						<a class="filter<?php echo ' '.$quicklink[3]; if ($isSelected) {
                       echo ' selected';
                   } ?>" href="<?php echo $quicklink[2]; ?>">
-					<a class="filter <?php if (parse_url($tplHelper->makeSelfUrl('full'), PHP_URL_QUERY) == parse_url($tplHelper->makeBaseUrl('full').$quicklink[2], PHP_URL_QUERY)) {
-                      echo ' selected';
-                  } ?>" href="<?php echo $quicklink[2]; ?>">
-					<span class='spoticon spoticon-<?php echo str_replace('images/icons/', '', str_replace('.png', '', $quicklink[1])); ?>'>&nbsp;</span><?php echo gettext($quicklink[0]);
+							<span class='spoticon spoticon-<?php echo str_replace('images/icons/', '', str_replace('.png', '', $quicklink[1])); ?>'>&nbsp;</span><?php echo gettext($quicklink[0]);
                   if ($newCount > 0) {
                       echo "<span class='newspots'>".$newCount.'</span>';
-                  } ?></a>
+                  } ?>
+						</a>
+					</li>
 <?php
               }
           }


### PR DESCRIPTION
1. Mobile filters now persist across search:
   - Selected filters on mobile are saved and re-applied when searching.
   - New `templates/mobile/includes/js/mobile-filters.js`.
   - Hooks added in `templates/mobile/header.inc.php` and `templates/mobile/filters.inc.php`.

2. Modern UI refinements:
   - Cards, sidebar layout, and table spacing tightened (smaller thumbs, more compact rows).
   - Density options removed from the toolbar.
   - Files: `templates/modern/css/cards.css`, `templates/modern/css/layout.css`, `templates/modern/css/table.css`,
     `templates/modern/js/theme-toggle.js`, `templates/modern/includes/header.inc.php`.

3. Modern filters restyled:
   - Modern filter sidebar now matches the classic we1rdo look (flat panels, classic category colors, compact spacing,
     classic toggle/inclusive icons).
   - File: `templates/modern/css/filters.css`.

4. Modern bug fix:
   - Cards comments link no longer triggers a comment-fetch loop.
   - File: `templates/modern/js/open-spot-fix.js`.

5. We1rdo tweaks:
   - Quicklinks HTML cleanup in filters.
   - Spam report icon sprite shifted by 1px for alignment.
   - Files: `templates/we1rdo/includes/filters.inc.php`, `templates/we1rdo/css/style.css`.
