### PR TITLE
Newznab Offset Fix

### DIFF
--- a/lib/page/SpotPage_newznabapi.php
+++ b/lib/page/SpotPage_newznabapi.php
@@ -326,10 +326,15 @@ class SpotPage_newznabapi extends SpotPage_Abs
         } // else
 
         if ((!empty($this->_params['offset'])) && is_numeric($this->_params['offset'])) {
-            $pageNr = $this->_params['offset'];
+            $offset = (int) $this->_params['offset'];
         } else {
-            $pageNr = 0;
+            $offset = 0;
         } // else
+
+        // Convert offset to page number for fetchSpotList
+        $pageNr = (int) floor($offset / $limit);
+        // Calculate actual offset used (aligned to page boundary)
+        $offset = $pageNr * $limit;
 
         /*
          * We get a bunch of query parameters, so now change this to the actual
@@ -360,7 +365,7 @@ class SpotPage_newznabapi extends SpotPage_Abs
             $parsedSearch
         );
 
-        $this->showResults($spotsTmp, $pageNr * $limit, $outputtype);
+        $this->showResults($spotsTmp, $offset, $outputtype);
     }
 
     // search

--- a/lib/page/SpotPage_newznabapi.php
+++ b/lib/page/SpotPage_newznabapi.php
@@ -373,6 +373,12 @@ class SpotPage_newznabapi extends SpotPage_Abs
     {
         $nzbhandling = $this->_currentSession['user']['prefs']['nzbhandling'];
 
+        /*
+         * Calculate total using hasmore flag to avoid expensive COUNT query.
+         */
+        $pageCount = count($spots['list']);
+        $total = $offset + $pageCount + ($spots['hasmore'] ? 1 : 0);
+
         if ($outputtype == 'json') {
             $doc = [];
             foreach ($spots['list'] as $spot) {
@@ -400,7 +406,7 @@ class SpotPage_newznabapi extends SpotPage_Abs
                 $data['category_ids'] = $cat;
 
                 if (empty($doc)) {
-                    $data['_totalrows'] = count($spots['list']);
+                    $data['_totalrows'] = $total;
                 }
 
                 $doc[] = $data;
@@ -442,7 +448,7 @@ class SpotPage_newznabapi extends SpotPage_Abs
 
             $newznabResponse = $doc->createElement('newznab:response');
             $newznabResponse->setAttribute('offset', $offset);
-            $newznabResponse->setAttribute('total', count($spots['list']));
+            $newznabResponse->setAttribute('total', $total);
             $channel->appendChild($newznabResponse);
 
             foreach ($spots['list'] as $spot) {


### PR DESCRIPTION
This PR resolves two key issues:

- Newznab clients expect the total to be the total number of records. So if the total is the number of records on the current page, the clients believe that they have retrieved all the records. By leveraging `hasmore`, we can inform the client that these are not all of the records. Since we retrieve a whole page on any request, we don't have to calculate the actual total, which can be an expensive query.
- The offset provided in the API was being treated as a page number instead of an actual offset, which is not on the Newznab spec. This treats the offset as an actual offset, and also sets the page number for fetchSpotList.