### PR TITLE
Show NZB handler action in all themes

### DIFF
--- a/templates/mobile/spotinfo.inc.php
+++ b/templates/mobile/spotinfo.inc.php
@@ -8,11 +8,17 @@
     // fix the sabnzbdurl and searchurl
     $spot['sabnzbdurl'] = $tplHelper->makeSabnzbdUrl($spot);
     $spot['searchurl'] = $tplHelper->makeSearchUrl($spot);
+    $showNzbHandlerButton = (
+        !empty($spot['nzb']) &&
+        ($spot['stamp'] > 1290578400) &&
+        $tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '')
+    );
+    $nzbHandlerPrefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
 ?>
 <div data-role="page" id="spots"> 
 	<div data-role="header" data-backbtn="false">
 	<h1>Spot info</h1>
-        <?php if (!empty($spot['sabnzbdurl']) and $spot['nzbhandlertype'] != 'save') { ?>
+        <?php if ($showNzbHandlerButton && !empty($spot['sabnzbdurl']) && $spot['nzbhandlertype'] != 'save') { ?>
         <script type="text/javascript">
             $("#loadnzb").on( "click", function(e) {
                                                     $("#loadnzb") .html("Wait..")
@@ -33,8 +39,22 @@
                                                    })
         </script>
         <a href="<?php echo $spot['sabnzbdurl']; ?>" id="loadnzb"   data-transition='fade' data-rel="dialog" data-icon="plus" class="ui-btn-right">Push NZB</a></th>
-<?php } else { ?>
-        <a href="<?php echo $setpath ?>index.php?page=getnzb&amp;messageid=<?php echo $spot['messageid']; ?>" data-ajax="false" data-transition='fade' data-icon="arrow-d" data-rel="dialog" class="ui-btn-right">NZB</a>
+<?php } elseif ($showNzbHandlerButton) { ?>
+        <script type="text/javascript">
+            function promptMobileNzbHandlerSetup(event, preferencesUrl) {
+                if (event) {
+                    event.preventDefault();
+                }
+
+                var message = <?php echo json_encode(_('No download client is configured. Configure NZB handling in your preferences first.'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+                var openPreferences = <?php echo json_encode(_('Open preferences now?'), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT); ?>;
+                if (window.confirm(message + "\n\n" + openPreferences) && preferencesUrl) {
+                    window.location.href = preferencesUrl;
+                }
+                return false;
+            }
+        </script>
+        <a href="<?php echo $nzbHandlerPrefsUrl; ?>" onclick="return promptMobileNzbHandlerSetup(event, this.href)" data-ajax="false" data-icon="plus" class="ui-btn-right">Push NZB</a>
 <?php } ?>
 	
 	</div>

--- a/templates/modern/css/cards.css
+++ b/templates/modern/css/cards.css
@@ -56,6 +56,13 @@
 .spotCard .actions { display: flex; align-items: center; gap: 5px; margin-top: 2px; }
 .spotCard .actions a.nzb { background: var(--color-accent); color: #fff; border-radius: 6px; padding: 4px 8px; text-decoration: none; font-weight: 600; }
 .spotCard .actions a.nzb.downloaded { opacity: 0.75; }
+.spotCard .actions a.sabnzbd-button { display: inline-block; width: 20px; height: 17px; cursor: pointer; margin: 0 2px 1px 0; background: url(../img/sprite.png) no-repeat 0 -94px; }
+.spotCard .actions a.sabnzbd-button.loading { background: url(../img/loading.gif) no-repeat center center; }
+.spotCard .actions a.sabnzbd-button.succes { background-position: -20px -94px; }
+.spotCard .actions a.sabnzbd-button.failure { background-position: 0 -182px; }
+.spotCard .actions a.sabnzbd-button.unconfigured { opacity: 0.5; filter: grayscale(1); }
+.spotCard .actions a.sabnzbd-button.unconfigured:hover,
+.spotCard .actions a.sabnzbd-button.unconfigured:focus { opacity: 0.85; }
 
 .spotCard .footerRow { display: flex; align-items: center; justify-content: space-between; margin-top: 2px; }
 .spotCard .comments { font-weight: 700; color: var(--color-accent); text-decoration: none; }

--- a/templates/modern/css/style.css
+++ b/templates/modern/css/style.css
@@ -344,6 +344,15 @@ div.details table.spotheader th.sabnzbd a.sabnzbd-button.succes,
 table.spots tr td a.sabnzbd-button.succes {background-position:-20px -94px;}
 div.details table.spotheader th.sabnzbd a.sabnzbd-button.failure,
 table.spots tr td a.sabnzbd-button.failure {background-position:0px -182px;}
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured,
+table.spots tr td a.sabnzbd-button.unconfigured,
+table.spots th.sabnzbd a.unconfigured {opacity:.45; filter:grayscale(1);}
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured:hover,
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured:focus,
+table.spots tr td a.sabnzbd-button.unconfigured:hover,
+table.spots tr td a.sabnzbd-button.unconfigured:focus,
+table.spots th.sabnzbd a.unconfigured:hover,
+table.spots th.sabnzbd a.unconfigured:focus {opacity:.8;}
 
 div.details table.spotheader th.spamreport a.spamreport-button,
 table.spots tr td a.spamreport-button {display:block; width:22px; height:18px; cursor:pointer; margin:0 0 1px 0; background:url(../img/sprite.png) no-repeat -55px -129px;}

--- a/templates/modern/js/scripts.js
+++ b/templates/modern/js/scripts.js
@@ -849,6 +849,21 @@ function downloadMultiNZB(dltype) {
 	}
 }
 
+function promptNzbHandlerSetup(event, preferencesUrl) {
+    if (event) {
+        event.preventDefault();
+    }
+
+    var message = "<t>No download client is configured. Configure NZB handling in your preferences first.</t>";
+    var openPreferences = "<t>Open preferences now?</t>";
+
+    if (window.confirm(message + "\n\n" + openPreferences) && preferencesUrl) {
+        window.location.href = preferencesUrl;
+    }
+
+    return false;
+}
+
 // Toggle filter visibility
 function attachFilterVisibility() {
 // console.time("9th-ready");

--- a/templates/modern/spotinfo.inc.php
+++ b/templates/modern/spotinfo.inc.php
@@ -30,6 +30,8 @@
     $show_editor = $tplHelper->allowed(SpotSecurity::spotsec_view_spot_editor, '');
     $hasWebsite = !empty(trim((string) $spot['website']));
     $hasTag = !empty(trim((string) $spot['tag']));
+    $nzbHandlerPrefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
+    $configureNzbHandlerTitle = htmlspecialchars(_('Configure NZB handling before sending this spot to a download client'), ENT_QUOTES);
 
     /* Determine minimal width of the image, we cannot set it in the CSS because we cannot calculate it there */
     $imgMinWidth = 260;
@@ -97,11 +99,13 @@
     echo " title='"._('Place in watchlist (w)')."'> </a>";
     echo '</th>';
 } ?>
-<?php if ((!empty($spot['nzb'])) && (!empty($spot['sabnzbdurl']))) { ?>
-<?php if ($spot['hasbeendownloaded']) { ?>
+<?php if ($show_nzb_button) { ?>
+<?php if (!empty($spot['sabnzbdurl']) && $spot['hasbeendownloaded']) { ?>
 						<th class="sabnzbd"><a onclick="downloadSabnzbd(<?php echo "'".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."'"; ?>)" class="<?php echo 'sab_'.$spot['id'].''; ?> sabnzbd-button succes" title="<?php echo _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)'); ?>"> </a></th>
-<?php } else { ?>
+<?php } elseif (!empty($spot['sabnzbdurl'])) { ?>
 						<th class="sabnzbd"><a onclick="downloadSabnzbd(<?php echo "'".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."'"; ?>)" class="<?php echo 'sab_'.$spot['id'].''; ?> sabnzbd-button" title="<?php echo _('Add NZB to SABnzbd queue (s)'); ?>"> </a></th>
+<?php } else { ?>
+						<th class="sabnzbd"><a href="<?php echo $nzbHandlerPrefsUrl; ?>" onclick="return promptNzbHandlerSetup(event, this.href)" class="sabnzbd-button unconfigured" title="<?php echo $configureNzbHandlerTitle; ?>" aria-label="<?php echo $configureNzbHandlerTitle; ?>"> </a></th>
 <?php } } ?>
 					</tr>
 				</tbody>

--- a/templates/modern/spots.inc.php
+++ b/templates/modern/spots.inc.php
@@ -122,6 +122,11 @@ document.addEventListener("DOMContentLoaded", function() {
                 $sabTitle = $spot['hasbeendownloaded'] ? _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)') : _('Add NZB to SABnzbd queue (s)');
                 $sabClass = 'sab_'.$spot['id'].' sabnzbd-button'.($spot['hasbeendownloaded'] ? ' succes' : '');
                 echo '    <a onclick="downloadSabnzbd(\''.$spot['id'].'\',\''.$spot['sabnzbdurl'].'\',\''.$spot['nzbhandlertype'].'\')" class="'.$sabClass.'" title="'.$sabTitle.'"> </a>';
+            } else {
+                $prefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
+                $configureTitle = _('Configure NZB handling before sending this spot to a download client');
+                $configureTitle = htmlspecialchars($configureTitle, ENT_QUOTES);
+                echo '    <a href="'.$prefsUrl.'" onclick="return promptNzbHandlerSetup(event, this.href)" class="sabnzbd-button unconfigured" title="'.$configureTitle.'" aria-label="'.$configureTitle.'"> </a>';
             }
             echo '  </div>';
 

--- a/templates/modern/spots.table.inc.php
+++ b/templates/modern/spots.table.inc.php
@@ -16,7 +16,10 @@
     $minimum_spamreports = $currentSession['user']['prefs']['minimum_reportcount'];
     $show_nzb_button = ($tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '') && ($currentSession['user']['prefs']['show_nzbbutton']));
     $show_multinzb_checkbox = ($tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '') && ($currentSession['user']['prefs']['show_multinzb']));
+    $show_nzbhandler_button = $tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '');
     $show_mouseover_subcats = ($currentSession['user']['prefs']['mouseover_subcats']);
+    $nzbHandlerPrefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
+    $configureNzbHandlerTitle = htmlspecialchars(_('Configure NZB handling before sending this spot to a download client'), ENT_QUOTES);
     $newCommentCount = [];
     $noResults = (count($spots) == 0);
     $show_editspot_button = ($tplHelper->allowed(SpotSecurity::spotsec_view_spotdetail, '') && $tplHelper->allowed(SpotSecurity::spotsec_edit_spotdetail, ''));
@@ -64,8 +67,14 @@
 							</th>
 <?php } ?>						
 <?php $nzbHandlingTmp = $currentSession['user']['prefs']['nzbhandling'];
-if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlingTmp['action'])) && ($nzbHandlingTmp['action'] != 'disable')) { ?>
-							<th class='sabnzbd'><a class="toggle" onclick="toggleSidebarPanel('.sabnzbdPanel')" title='<?php echo sprintf(_('Open "%s" panel'), $tplHelper->getNzbHandlerName()); ?>'></a></th>
+if ($show_nzbhandler_button) { ?>
+							<th class='sabnzbd'>
+<?php if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlingTmp['action'])) && ($nzbHandlingTmp['action'] != 'disable')) { ?>
+								<a class="toggle" onclick="toggleSidebarPanel('.sabnzbdPanel')" title='<?php echo sprintf(_('Open "%s" panel'), $tplHelper->getNzbHandlerName()); ?>'></a>
+<?php } else { ?>
+								<a class="unconfigured" href="<?php echo $nzbHandlerPrefsUrl; ?>" onclick="return promptNzbHandlerSetup(event, this.href)" title="<?php echo $configureNzbHandlerTitle; ?>"></a>
+<?php } ?>
+							</th>
 <?php } ?>						
 						</tr>
 					</thead>
@@ -92,7 +101,7 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
         if ($show_watchlist_button) {
             $colSpan++;
         }
-        if ($nzbHandlingTmp['action'] != 'disable') {
+        if ($show_nzbhandler_button) {
             $colSpan++;
         }
 
@@ -239,13 +248,21 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo '</td>';
                 } // if
 
-                // display the SABnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // display the configured NZB handler, or link to its preferences
+                if ($show_nzbhandler_button) {
                     if ($spot['hasbeendownloaded']) {
-                        echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button succes' title='"._('Add NZB to SABnzbd queue (you already downloaded this spot) (s)')."'> </a></td>";
+                        $downloadedClass = ' succes';
                     } else {
-                        echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button' title='"._('Add NZB to SABnzbd queue (s)')."'> </a></td>";
-                    } // else
+                        $downloadedClass = '';
+                    }
+                    echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'>";
+                    if (!empty($spot['sabnzbdurl'])) {
+                        $sabTitle = $spot['hasbeendownloaded'] ? _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)') : _('Add NZB to SABnzbd queue (s)');
+                        echo "<a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button".$downloadedClass."' title='".$sabTitle."'> </a>";
+                    } else {
+                        echo "<a href='".$nzbHandlerPrefsUrl."' onclick=\"return promptNzbHandlerSetup(event, this.href)\" class='sabnzbd-button unconfigured' title='".$configureNzbHandlerTitle."' aria-label='".$configureNzbHandlerTitle."'> </a>";
+                    }
+                    echo '</td>';
                 } // if
             } else {
                 if ($show_nzb_button) {
@@ -257,8 +274,8 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo "<td class='multinzb ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'> &nbsp; </td>";
                 }
 
-                // display the sabnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // keep the NZB handler column aligned for spots without an NZB
+                if ($show_nzbhandler_button) {
                     echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'> &nbsp; </td>";
                 } // if
             } // else
@@ -325,13 +342,21 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo '</td>';
                 } // if
 
-                // display the SABnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // display the configured NZB handler, or link to its preferences
+                if ($show_nzbhandler_button) {
                     if ($spot['hasbeendownloaded']) {
-                        echo "<td class='sabnzbd'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button succes' title='"._('Add NZB to SABnzbd queue (you already downloaded this spot) (s)')."'> </a></td>";
+                        $downloadedClass = ' succes';
                     } else {
-                        echo "<td class='sabnzbd'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button' title='"._('Add NZB to SABnzbd queue (s)')."'> </a></td>";
-                    } // else
+                        $downloadedClass = '';
+                    }
+                    echo "<td class='sabnzbd'>";
+                    if (!empty($spot['sabnzbdurl'])) {
+                        $sabTitle = $spot['hasbeendownloaded'] ? _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)') : _('Add NZB to SABnzbd queue (s)');
+                        echo "<a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button".$downloadedClass."' title='".$sabTitle."'> </a>";
+                    } else {
+                        echo "<a href='".$nzbHandlerPrefsUrl."' onclick=\"return promptNzbHandlerSetup(event, this.href)\" class='sabnzbd-button unconfigured' title='".$configureNzbHandlerTitle."' aria-label='".$configureNzbHandlerTitle."'> </a>";
+                    }
+                    echo '</td>';
                 } // if
             } else {
                 if ($show_nzb_button) {
@@ -343,8 +368,8 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo "<td class='multinzb'> &nbsp; </td>";
                 }
 
-                // display the sabnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // keep the NZB handler column aligned for spots without an NZB
+                if ($show_nzbhandler_button) {
                     echo "<td class='sabnzbd'> &nbsp; </td>";
                 } // if
             } // else

--- a/templates/we1rdo/css/style.css
+++ b/templates/we1rdo/css/style.css
@@ -355,6 +355,15 @@ div.details table.spotheader th.sabnzbd a.sabnzbd-button.succes,
 table.spots tr td a.sabnzbd-button.succes {background-position:-20px -94px;}
 div.details table.spotheader th.sabnzbd a.sabnzbd-button.failure,
 table.spots tr td a.sabnzbd-button.failure {background-position:0px -182px;}
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured,
+table.spots tr td a.sabnzbd-button.unconfigured,
+table.spots th.sabnzbd a.unconfigured {opacity:.45; filter:grayscale(1);}
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured:hover,
+div.details table.spotheader th.sabnzbd a.sabnzbd-button.unconfigured:focus,
+table.spots tr td a.sabnzbd-button.unconfigured:hover,
+table.spots tr td a.sabnzbd-button.unconfigured:focus,
+table.spots th.sabnzbd a.unconfigured:hover,
+table.spots th.sabnzbd a.unconfigured:focus {opacity:.8;}
 
 div.details table.spotheader th.spamreport a.spamreport-button,
 table.spots tr td a.spamreport-button {display:block; width:22px; height:18px; cursor:pointer; margin:0 0 1px 0; background:url(../img/sprite.png) no-repeat -55px -129px;}

--- a/templates/we1rdo/js/scripts.js
+++ b/templates/we1rdo/js/scripts.js
@@ -894,6 +894,21 @@ function downloadMultiNZB(dltype) {
 	}
 }
 
+function promptNzbHandlerSetup(event, preferencesUrl) {
+    if (event) {
+        event.preventDefault();
+    }
+
+    var message = "<t>No download client is configured. Configure NZB handling in your preferences first.</t>";
+    var openPreferences = "<t>Open preferences now?</t>";
+
+    if (window.confirm(message + "\n\n" + openPreferences) && preferencesUrl) {
+        window.location.href = preferencesUrl;
+    }
+
+    return false;
+}
+
 // Toggle filter visibility
 function attachFilterVisibility() {
 // console.time("9th-ready");

--- a/templates/we1rdo/spotinfo.inc.php
+++ b/templates/we1rdo/spotinfo.inc.php
@@ -16,6 +16,8 @@
     $allow_whiteList = (($tplHelper->allowed(SpotSecurity::spotsec_blacklist_spotter, '')) && ($allowedToPost) && (!$isBlacklisted) && (!$isWhitelisted) && (!empty($spot['spotterid'])));
     $show_spot_edit = $tplHelper->allowed(SpotSecurity::spotsec_show_spot_was_edited, '');
     $show_editor = $tplHelper->allowed(SpotSecurity::spotsec_view_spot_editor, '');
+    $nzbHandlerPrefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
+    $configureNzbHandlerTitle = htmlspecialchars(_('Configure NZB handling before sending this spot to a download client'), ENT_QUOTES);
 
     /* Determine minimal width of the image, we cannot set it in the CSS because we cannot calculate it there */
     $imgMinWidth = 260;
@@ -83,11 +85,13 @@
     echo " title='"._('Place in watchlist (w)')."'> </a>";
     echo '</th>';
 } ?>
-<?php if ((!empty($spot['nzb'])) && (!empty($spot['sabnzbdurl']))) { ?>
-<?php if ($spot['hasbeendownloaded']) { ?>
+<?php if ($show_nzb_button) { ?>
+<?php if (!empty($spot['sabnzbdurl']) && $spot['hasbeendownloaded']) { ?>
 						<th class="sabnzbd"><a onclick="downloadSabnzbd(<?php echo "'".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."'"; ?>)" class="<?php echo 'sab_'.$spot['id'].''; ?> sabnzbd-button succes" title="<?php echo _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)'); ?>"> </a></th>
-<?php } else { ?>
+<?php } elseif (!empty($spot['sabnzbdurl'])) { ?>
 						<th class="sabnzbd"><a onclick="downloadSabnzbd(<?php echo "'".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."'"; ?>)" class="<?php echo 'sab_'.$spot['id'].''; ?> sabnzbd-button" title="<?php echo _('Add NZB to SABnzbd queue (s)'); ?>"> </a></th>
+<?php } else { ?>
+						<th class="sabnzbd"><a href="<?php echo $nzbHandlerPrefsUrl; ?>" onclick="return promptNzbHandlerSetup(event, this.href)" class="sabnzbd-button unconfigured" title="<?php echo $configureNzbHandlerTitle; ?>" aria-label="<?php echo $configureNzbHandlerTitle; ?>"> </a></th>
 <?php } } ?>
 					</tr>
 				</tbody>

--- a/templates/we1rdo/spots.inc.php
+++ b/templates/we1rdo/spots.inc.php
@@ -16,7 +16,10 @@
     $minimum_spamreports = $currentSession['user']['prefs']['minimum_reportcount'];
     $show_nzb_button = ($tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '') && ($currentSession['user']['prefs']['show_nzbbutton']));
     $show_multinzb_checkbox = ($tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '') && ($currentSession['user']['prefs']['show_multinzb']));
+    $show_nzbhandler_button = $tplHelper->allowed(SpotSecurity::spotsec_retrieve_nzb, '');
     $show_mouseover_subcats = ($currentSession['user']['prefs']['mouseover_subcats']);
+    $nzbHandlerPrefsUrl = $tplHelper->makeEditUserPrefsUrl($currentSession['user']['userid']);
+    $configureNzbHandlerTitle = htmlspecialchars(_('Configure NZB handling before sending this spot to a download client'), ENT_QUOTES);
     $newCommentCount = [];
     $noResults = (count($spots) == 0);
     $show_editspot_button = ($tplHelper->allowed(SpotSecurity::spotsec_view_spotdetail, '') && $tplHelper->allowed(SpotSecurity::spotsec_edit_spotdetail, ''));
@@ -64,8 +67,14 @@
 							</th>
 <?php } ?>						
 <?php $nzbHandlingTmp = $currentSession['user']['prefs']['nzbhandling'];
-if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlingTmp['action'])) && ($nzbHandlingTmp['action'] != 'disable')) { ?>
-							<th class='sabnzbd'><a class="toggle" onclick="toggleSidebarPanel('.sabnzbdPanel')" title='<?php echo sprintf(_('Open "%s" panel'), $tplHelper->getNzbHandlerName()); ?>'></a></th>
+if ($show_nzbhandler_button) { ?>
+							<th class='sabnzbd'>
+<?php if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlingTmp['action'])) && ($nzbHandlingTmp['action'] != 'disable')) { ?>
+								<a class="toggle" onclick="toggleSidebarPanel('.sabnzbdPanel')" title='<?php echo sprintf(_('Open "%s" panel'), $tplHelper->getNzbHandlerName()); ?>'></a>
+<?php } else { ?>
+								<a class="unconfigured" href="<?php echo $nzbHandlerPrefsUrl; ?>" onclick="return promptNzbHandlerSetup(event, this.href)" title="<?php echo $configureNzbHandlerTitle; ?>"></a>
+<?php } ?>
+							</th>
 <?php } ?>						
 						</tr>
 					</thead>
@@ -92,7 +101,7 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
         if ($show_watchlist_button) {
             $colSpan++;
         }
-        if ($nzbHandlingTmp['action'] != 'disable') {
+        if ($show_nzbhandler_button) {
             $colSpan++;
         }
 
@@ -239,13 +248,21 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo '</td>';
                 } // if
 
-                // display the SABnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // display the configured NZB handler, or link to its preferences
+                if ($show_nzbhandler_button) {
                     if ($spot['hasbeendownloaded']) {
-                        echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button succes' title='"._('Add NZB to SABnzbd queue (you already downloaded this spot) (s)')."'> </a></td>";
+                        $downloadedClass = ' succes';
                     } else {
-                        echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button' title='"._('Add NZB to SABnzbd queue (s)')."'> </a></td>";
-                    } // else
+                        $downloadedClass = '';
+                    }
+                    echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'>";
+                    if (!empty($spot['sabnzbdurl'])) {
+                        $sabTitle = $spot['hasbeendownloaded'] ? _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)') : _('Add NZB to SABnzbd queue (s)');
+                        echo "<a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button".$downloadedClass."' title='".$sabTitle."'> </a>";
+                    } else {
+                        echo "<a href='".$nzbHandlerPrefsUrl."' onclick=\"return promptNzbHandlerSetup(event, this.href)\" class='sabnzbd-button unconfigured' title='".$configureNzbHandlerTitle."' aria-label='".$configureNzbHandlerTitle."'> </a>";
+                    }
+                    echo '</td>';
                 } // if
             } else {
                 if ($show_nzb_button) {
@@ -257,8 +274,8 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo "<td class='multinzb ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'> &nbsp; </td>";
                 }
 
-                // display the sabnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // keep the NZB handler column aligned for spots without an NZB
+                if ($show_nzbhandler_button) {
                     echo "<td class='sabnzbd ".'hg1'.' '.$newSpotClass.' '.$tipTipClass."'> &nbsp; </td>";
                 } // if
             } // else
@@ -325,13 +342,21 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo '</td>';
                 } // if
 
-                // display the SABnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // display the configured NZB handler, or link to its preferences
+                if ($show_nzbhandler_button) {
                     if ($spot['hasbeendownloaded']) {
-                        echo "<td class='sabnzbd'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button succes' title='"._('Add NZB to SABnzbd queue (you already downloaded this spot) (s)')."'> </a></td>";
+                        $downloadedClass = ' succes';
                     } else {
-                        echo "<td class='sabnzbd'><a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button' title='"._('Add NZB to SABnzbd queue (s)')."'> </a></td>";
-                    } // else
+                        $downloadedClass = '';
+                    }
+                    echo "<td class='sabnzbd'>";
+                    if (!empty($spot['sabnzbdurl'])) {
+                        $sabTitle = $spot['hasbeendownloaded'] ? _('Add NZB to SABnzbd queue (you already downloaded this spot) (s)') : _('Add NZB to SABnzbd queue (s)');
+                        echo "<a onclick=\"downloadSabnzbd('".$spot['id']."','".$spot['sabnzbdurl']."','".$spot['nzbhandlertype']."')\" class='sab_".$spot['id']." sabnzbd-button".$downloadedClass."' title='".$sabTitle."'> </a>";
+                    } else {
+                        echo "<a href='".$nzbHandlerPrefsUrl."' onclick=\"return promptNzbHandlerSetup(event, this.href)\" class='sabnzbd-button unconfigured' title='".$configureNzbHandlerTitle."' aria-label='".$configureNzbHandlerTitle."'> </a>";
+                    }
+                    echo '</td>';
                 } // if
             } else {
                 if ($show_nzb_button) {
@@ -343,8 +368,8 @@ if (($tplHelper->allowed(SpotSecurity::spotsec_download_integration, $nzbHandlin
                     echo "<td class='multinzb'> &nbsp; </td>";
                 }
 
-                // display the sabnzbd button
-                if (!empty($spot['sabnzbdurl'])) {
+                // keep the NZB handler column aligned for spots without an NZB
+                if ($show_nzbhandler_button) {
                     echo "<td class='sabnzbd'> &nbsp; </td>";
                 } // if
             } // else


### PR DESCRIPTION
## What changed

- Always show the NZB handler action in the Modern cards, Modern table/detail, We1rdo table/detail, and Mobile detail views.
- Keep the existing direct-send behavior when a download client is configured.
- Show a muted action that explains the missing configuration and links to user preferences when no handler is configured.
- Preserve the normal NZB download link on mobile.

## Why

The Modern cards view did not expose the SABnzbd/download-client action consistently, and other themes hid the action entirely when NZB handling was disabled. This made it difficult for users to discover that a download client first needed to be configured.

## User impact

Users now see the action consistently across themes. An unconfigured handler is visually distinct and provides a clear setup prompt. Existing loading, success (green), and failure states remain unchanged for configured handlers.

## Validation

- `php -l` on all modified PHP templates
- `node --check` on the Modern and We1rdo scripts
- `git diff --check`
- Visual/runtime checks for Modern cards/table, We1rdo table, and Mobile detail views
- Verified 25 visible handler actions across 25 cards in the local Modern cards view
