### PR TITLE
fix: correct 'inconvience' to 'inconvenience' typo in cache migration error

### DIFF
--- a/bin/upgrade-db.php
+++ b/bin/upgrade-db.php
@@ -277,7 +277,7 @@ try {
         'size of your cache this can take a very long time.'.PHP_EOL.PHP_EOL.
         "Please run the 'bin/migrate-cache.php' script because attempting to run 'upgrade-db.php' again will erase your cache completely".PHP_EOL);
 } catch (CacheMustBeMigrated2Exception $x) {
-    exit('Apologies for the inconvience, but Spotweb has once again changed the way we store files for cache. This '.PHP_EOL.
+    exit('Apologies for the inconvenience, but Spotweb has once again changed the way we store files for cache. This '.PHP_EOL.
         "means you need to run the script 'migrate-cache2.php' again.  ".PHP_EOL.
         'Depending on the size of your cache this can take a very long time.'.PHP_EOL.PHP_EOL.
         "Please run the 'bin/migrate-cache.php2' script again");


### PR DESCRIPTION
User-facing exit() message when cache migration is required in bin/upgrade-db.php line 280.

Corrects spelling: convience -> inconvenience.

---
fixes typo